### PR TITLE
Error macros now take in exceptions

### DIFF
--- a/src/morphac/common/error_handling/include/error_macros.h
+++ b/src/morphac/common/error_handling/include/error_macros.h
@@ -4,28 +4,26 @@
 #include <iostream>
 
 #ifndef NDEBUG
-#define MORPH_ASSERT(conditon, error_message)                               \
+#define MORPH_ASSERT(conditon, error_message, exception)                    \
   {                                                                         \
     if (!(condition)) {                                                     \
       std::cerr << "------- Assertion failed -------" << std::endl;         \
       std::cerr << "Failed in file: " << __FILE__ << std::endl;             \
       std::cerr << "Failed inside function: " << __FUNCTION__ << std::endl; \
       std::cerr << "Failed at line: " << __LINE__ << std::endl;             \
-      std::cerr << "Failed with message: " << #error_message << std::endl;  \
-      std::exit(-2);                                                        \
+      throw exception(error_message);                                       \
     }                                                                       \
   }
 #endif
 
-#define MORPH_REQUIRE(condition, error_message)                             \
+#define MORPH_REQUIRE(condition, error_message, exception)                  \
   {                                                                         \
     if (!(condition)) {                                                     \
       std::cerr << "------- Requirement failed -------" << std::endl;       \
       std::cerr << "Failed in file: " << __FILE__ << std::endl;             \
       std::cerr << "Failed inside function: " << __FUNCTION__ << std::endl; \
       std::cerr << "Failed at line: " << __LINE__ << std::endl;             \
-      std::cerr << "Failed with message: " << #error_message << std::endl;  \
-      std::exit(-1);                                                        \
+      throw exception(error_message);                                       \
     }                                                                       \
   }
 

--- a/src/morphac/common/error_handling/include/error_macros.h
+++ b/src/morphac/common/error_handling/include/error_macros.h
@@ -4,7 +4,7 @@
 #include <iostream>
 
 #ifndef NDEBUG
-#define MORPH_ASSERT(conditon, error_message, exception)                    \
+#define MORPH_ASSERT(conditon, exception, error_message)                    \
   {                                                                         \
     if (!(condition)) {                                                     \
       std::cerr << "------- Assertion failed -------" << std::endl;         \
@@ -16,7 +16,7 @@
   }
 #endif
 
-#define MORPH_REQUIRE(condition, error_message, exception)                  \
+#define MORPH_REQUIRE(condition, exception, error_message)                  \
   {                                                                         \
     if (!(condition)) {                                                     \
       std::cerr << "------- Requirement failed -------" << std::endl;       \

--- a/src/morphac/constructs/include/pose.h
+++ b/src/morphac/constructs/include/pose.h
@@ -3,7 +3,7 @@
 
 #include "Eigen/Dense"
 
-#include "common/include/error_macros.h"
+#include "common/error_handling/include/error_macros.h"
 
 namespace morphac {
 namespace constructs {

--- a/src/morphac/constructs/src/pose.cc
+++ b/src/morphac/constructs/src/pose.cc
@@ -6,12 +6,13 @@ namespace constructs {
 using Eigen::VectorXd;
 
 Pose::Pose(int size) : size_(size) {
-  MORPH_REQUIRE(size > 0, "Pose size is non-positive.");
+  MORPH_REQUIRE(size > 0, "Pose size is non-positive.", std::invalid_argument);
   pose_ = VectorXd::Zero(size);
 }
 
 Pose::Pose(VectorXd pose) {
-  MORPH_REQUIRE(pose.size() > 0, "Pose size is non-positive.");
+  MORPH_REQUIRE(pose.size() > 0, "Pose size is non-positive.",
+                std::invalid_argument);
   size_ = pose.size();
   pose_ = pose;
 }
@@ -26,18 +27,21 @@ int Pose::get_size() { return size_; }
 VectorXd Pose::get_pose() { return pose_; }
 
 double Pose::get_pose(int index) {
-  MORPH_REQUIRE(index >= 0 && index < size_, "Pose index out of bounds.");
+  MORPH_REQUIRE(index >= 0 && index < size_, "Pose index out of bounds.",
+                std::out_of_range);
   return pose_(index);
 }
 
 void Pose::set_pose(VectorXd pose) {
-  MORPH_REQUIRE(pose.size() > 0, "Pose size is non-positive.");
+  MORPH_REQUIRE(pose.size() > 0, "Pose size is non-positive.",
+                std::invalid_argument);
   size_ = pose.size();
   pose_ = pose;
 }
 
 void Pose::set_pose(int index, double pose_element) {
-  MORPH_REQUIRE(index >= 0 && index < size_, "Pose index out of bounds.");
+  MORPH_REQUIRE(index >= 0 && index < size_, "Pose index out of bounds.",
+                std::out_of_range);
   pose_(index) = pose_element;
 }
 

--- a/src/morphac/constructs/src/pose.cc
+++ b/src/morphac/constructs/src/pose.cc
@@ -6,13 +6,13 @@ namespace constructs {
 using Eigen::VectorXd;
 
 Pose::Pose(int size) : size_(size) {
-  MORPH_REQUIRE(size > 0, "Pose size is non-positive.", std::invalid_argument);
+  MORPH_REQUIRE(size > 0, std::invalid_argument, "Pose size is non-positive.");
   pose_ = VectorXd::Zero(size);
 }
 
 Pose::Pose(VectorXd pose) {
-  MORPH_REQUIRE(pose.size() > 0, "Pose size is non-positive.",
-                std::invalid_argument);
+  MORPH_REQUIRE(pose.size() > 0, std::invalid_argument,
+                "Pose size is non-positive.");
   size_ = pose.size();
   pose_ = pose;
 }
@@ -27,21 +27,21 @@ int Pose::get_size() { return size_; }
 VectorXd Pose::get_pose() { return pose_; }
 
 double Pose::get_pose(int index) {
-  MORPH_REQUIRE(index >= 0 && index < size_, "Pose index out of bounds.",
-                std::out_of_range);
+  MORPH_REQUIRE(index >= 0 && index < size_, std::out_of_range,
+                "Pose index out of bounds.");
   return pose_(index);
 }
 
 void Pose::set_pose(VectorXd pose) {
-  MORPH_REQUIRE(pose.size() > 0, "Pose size is non-positive.",
-                std::invalid_argument);
+  MORPH_REQUIRE(pose.size() > 0, std::invalid_argument,
+                "Pose size is non-positive.");
   size_ = pose.size();
   pose_ = pose;
 }
 
 void Pose::set_pose(int index, double pose_element) {
-  MORPH_REQUIRE(index >= 0 && index < size_, "Pose index out of bounds.",
-                std::out_of_range);
+  MORPH_REQUIRE(index >= 0 && index < size_, std::out_of_range,
+                "Pose index out of bounds.");
   pose_(index) = pose_element;
 }
 

--- a/src/morphac/constructs/test/pose_test.cc
+++ b/src/morphac/constructs/test/pose_test.cc
@@ -41,14 +41,20 @@ TEST_F(PoseTest, SetPose) {
   ASSERT_EQ(pose3_.get_pose(1), 7.0);
 }
 
+TEST_F(PoseTest, InvalidConstruction) {
+  ASSERT_THROW(Pose(0), std::invalid_argument);
+  ASSERT_THROW(Pose(VectorXd::Random(0)), std::invalid_argument);
+}
+
 TEST_F(PoseTest, InvalidGet) {
-  ASSERT_DEATH(pose1_.get_pose(-1), "");
-  ASSERT_DEATH(pose1_.get_pose(3), "");
+  ASSERT_THROW(pose1_.get_pose(-1), std::out_of_range);
+  ASSERT_THROW(pose1_.get_pose(3), std::out_of_range);
 }
 
 TEST_F(PoseTest, InvalidSet) {
-  ASSERT_DEATH(pose1_.set_pose(-1, 1), "");
-  ASSERT_DEATH(pose1_.set_pose(7, 1), "");
+  ASSERT_THROW(pose1_.set_pose(-1, 1), std::out_of_range);
+  ASSERT_THROW(pose1_.set_pose(7, 1), std::out_of_range);
+  ASSERT_THROW(pose1_.set_pose(VectorXd::Random(0)), std::invalid_argument);
 }
 
 }  // namespace

--- a/src/morphac/environments/include/environment2D.h
+++ b/src/morphac/environments/include/environment2D.h
@@ -3,7 +3,7 @@
 
 #include "Eigen/Dense"
 
-#include "common/include/error_macros.h"
+#include "common/error_handling/include/error_macros.h"
 
 namespace morphac {
 namespace environments {

--- a/src/morphac/environments/src/environment2D.cc
+++ b/src/morphac/environments/src/environment2D.cc
@@ -7,19 +7,19 @@ using Eigen::MatrixXd;
 
 Environment2D::Environment2D(int width, int height)
     : width_(width), height_(height) {
-  MORPH_REQUIRE(width_ > 0, "Non-positive environment width.",
-                std::invalid_argument);
-  MORPH_REQUIRE(height_ > 0, "Non-positive environment height.",
-                std::invalid_argument);
+  MORPH_REQUIRE(width_ > 0, std::invalid_argument,
+                "Non-positive environment width.");
+  MORPH_REQUIRE(height_ > 0, std::invalid_argument,
+                "Non-positive environment height.");
   map_ = MatrixXd::Zero(height_, width_);
 }
 
 Environment2D::Environment2D(MatrixXd map)
     : width_(map.cols()), height_(map.rows()) {
-  MORPH_REQUIRE(map.cols() > 0, "Non-positive map width.",
-                std::invalid_argument);
-  MORPH_REQUIRE(map.rows() > 0, "Non-positive map height.",
-                std::invalid_argument);
+  MORPH_REQUIRE(map.cols() > 0, std::invalid_argument,
+                "Non-positive map width.");
+  MORPH_REQUIRE(map.rows() > 0, std::invalid_argument,
+                "Non-positive map height.");
   map_ = map;
 }
 
@@ -31,10 +31,10 @@ MatrixXd Environment2D::get_map() { return map_; }
 
 void Environment2D::set_map(MatrixXd map) {
   // The map needs to have the same dimensions
-  MORPH_REQUIRE(map.cols() == width_, "Map width does not match.",
-                std::invalid_argument);
-  MORPH_REQUIRE(map.rows() == height_, "Map height does not match.",
-                std::invalid_argument);
+  MORPH_REQUIRE(map.cols() == width_, std::invalid_argument,
+                "Map width does not match.");
+  MORPH_REQUIRE(map.rows() == height_, std::invalid_argument,
+                "Map height does not match.");
   map_ = map;
 }
 

--- a/src/morphac/environments/src/environment2D.cc
+++ b/src/morphac/environments/src/environment2D.cc
@@ -7,15 +7,19 @@ using Eigen::MatrixXd;
 
 Environment2D::Environment2D(int width, int height)
     : width_(width), height_(height) {
-  MORPH_REQUIRE(width_ > 0, "Non-positive environment width.");
-  MORPH_REQUIRE(height_ > 0, "Non-positive environment height.");
+  MORPH_REQUIRE(width_ > 0, "Non-positive environment width.",
+                std::invalid_argument);
+  MORPH_REQUIRE(height_ > 0, "Non-positive environment height.",
+                std::invalid_argument);
   map_ = MatrixXd::Zero(height_, width_);
 }
 
 Environment2D::Environment2D(MatrixXd map)
     : width_(map.cols()), height_(map.rows()) {
-  MORPH_REQUIRE(map.cols() > 0, "Non-positive map width.");
-  MORPH_REQUIRE(map.rows() > 0, "Non-positive map height.");
+  MORPH_REQUIRE(map.cols() > 0, "Non-positive map width.",
+                std::invalid_argument);
+  MORPH_REQUIRE(map.rows() > 0, "Non-positive map height.",
+                std::invalid_argument);
   map_ = map;
 }
 
@@ -27,8 +31,10 @@ MatrixXd Environment2D::get_map() { return map_; }
 
 void Environment2D::set_map(MatrixXd map) {
   // The map needs to have the same dimensions
-  MORPH_REQUIRE(map.cols() == width_, "Map width does not match.");
-  MORPH_REQUIRE(map.rows() == height_, "Map height does not match.");
+  MORPH_REQUIRE(map.cols() == width_, "Map width does not match.",
+                std::invalid_argument);
+  MORPH_REQUIRE(map.rows() == height_, "Map height does not match.",
+                std::invalid_argument);
   map_ = map;
 }
 


### PR DESCRIPTION
* `MORPH_ASSERT` and `MORPH_REQUIRE` now need an exception parameter.
* Standard exceptions have been used for now. Specific subclasses may be written and used later on if required.