### PR TITLE
Specific models

### DIFF
--- a/src/morphac/constructs/include/control_input.h
+++ b/src/morphac/constructs/include/control_input.h
@@ -10,6 +10,7 @@ namespace constructs {
 
 class ControlInput {
  public:
+  ControlInput();
   ControlInput(const int size);
   ControlInput(const Eigen::VectorXd& input_vector);
 
@@ -19,6 +20,7 @@ class ControlInput {
   ControlInput operator-(const ControlInput& input);
   ControlInput& operator*=(const double scalar);
 
+  bool is_empty() const;
   const int get_size() const;
   const Eigen::VectorXd& get_input_vector() const;
   double get_input_at(int index) const;

--- a/src/morphac/constructs/include/control_input.h
+++ b/src/morphac/constructs/include/control_input.h
@@ -27,6 +27,9 @@ class ControlInput {
   const Eigen::VectorXd& get_input_vector() const;
   void set_input_vector(const Eigen::VectorXd& input_vector);
 
+  static ControlInput CreateLike(
+      const morphac::constructs::ControlInput& input);
+
  private:
   const int size_;
   Eigen::VectorXd input_vector_;

--- a/src/morphac/constructs/include/control_input.h
+++ b/src/morphac/constructs/include/control_input.h
@@ -22,11 +22,11 @@ class ControlInput {
   double& operator()(const int index);
   double operator()(const int index) const;
 
-  bool is_empty() const;
   const int get_size() const;
   const Eigen::VectorXd& get_input_vector() const;
   void set_input_vector(const Eigen::VectorXd& input_vector);
 
+  bool IsEmpty() const;
   static ControlInput CreateLike(
       const morphac::constructs::ControlInput& input);
 

--- a/src/morphac/constructs/include/control_input.h
+++ b/src/morphac/constructs/include/control_input.h
@@ -20,6 +20,7 @@ class ControlInput {
   ControlInput& operator*=(const double scalar);
 
   double& operator()(const int index);
+  double operator()(const int index) const;
 
   bool is_empty() const;
   const int get_size() const;

--- a/src/morphac/constructs/include/control_input.h
+++ b/src/morphac/constructs/include/control_input.h
@@ -19,12 +19,12 @@ class ControlInput {
   ControlInput operator-(const ControlInput& input);
   ControlInput& operator*=(const double scalar);
 
+  double& operator()(const int index);
+
   bool is_empty() const;
   const int get_size() const;
   const Eigen::VectorXd& get_input_vector() const;
-  double get_input_at(int index) const;
   void set_input_vector(const Eigen::VectorXd& input_vector);
-  void set_input_at(int index, double input_element);
 
  private:
   const int size_;

--- a/src/morphac/constructs/include/control_input.h
+++ b/src/morphac/constructs/include/control_input.h
@@ -10,8 +10,7 @@ namespace constructs {
 
 class ControlInput {
  public:
-  ControlInput();
-  ControlInput(const int size);
+  ControlInput(const int size = 0);
   ControlInput(const Eigen::VectorXd& input_vector);
 
   ControlInput& operator+=(const ControlInput& input);

--- a/src/morphac/constructs/include/pose.h
+++ b/src/morphac/constructs/include/pose.h
@@ -22,11 +22,11 @@ class Pose {
   double& operator()(const int index);
   double operator()(const int index) const;
 
-  bool is_empty() const;
   const int get_size() const;
   const Eigen::VectorXd& get_pose_vector() const;
   void set_pose_vector(const Eigen::VectorXd& pose_vector);
 
+  bool IsEmpty() const;
   static Pose CreateLike(const morphac::constructs::Pose& pose);
 
  private:

--- a/src/morphac/constructs/include/pose.h
+++ b/src/morphac/constructs/include/pose.h
@@ -10,8 +10,7 @@ namespace constructs {
 
 class Pose {
  public:
-  Pose();
-  Pose(const int size);
+  Pose(const int size = 0);
   Pose(const Eigen::VectorXd& pose_vector);
 
   Pose& operator+=(const Pose& pose);

--- a/src/morphac/constructs/include/pose.h
+++ b/src/morphac/constructs/include/pose.h
@@ -10,7 +10,8 @@ namespace constructs {
 
 class Pose {
  public:
-  Pose( const int size);
+  Pose();
+  Pose(const int size);
   Pose(const Eigen::VectorXd& pose_vector);
 
   Pose& operator+=(const Pose& pose);
@@ -19,6 +20,7 @@ class Pose {
   Pose operator-(const Pose& pose);
   Pose& operator*=(const double scalar);
 
+  bool is_empty() const;
   const int get_size() const;
   const Eigen::VectorXd& get_pose_vector() const;
   double get_pose_at(int index) const;

--- a/src/morphac/constructs/include/pose.h
+++ b/src/morphac/constructs/include/pose.h
@@ -19,12 +19,12 @@ class Pose {
   Pose operator-(const Pose& pose);
   Pose& operator*=(const double scalar);
 
+  double& operator()(const int index);
+
   bool is_empty() const;
   const int get_size() const;
   const Eigen::VectorXd& get_pose_vector() const;
-  double get_pose_at(int index) const;
   void set_pose_vector(const Eigen::VectorXd& pose_vector);
-  void set_pose_at(int index, double pose_element);
 
  private:
   const int size_;

--- a/src/morphac/constructs/include/pose.h
+++ b/src/morphac/constructs/include/pose.h
@@ -20,6 +20,7 @@ class Pose {
   Pose& operator*=(const double scalar);
 
   double& operator()(const int index);
+  double operator()(const int index) const;
 
   bool is_empty() const;
   const int get_size() const;

--- a/src/morphac/constructs/include/pose.h
+++ b/src/morphac/constructs/include/pose.h
@@ -27,6 +27,8 @@ class Pose {
   const Eigen::VectorXd& get_pose_vector() const;
   void set_pose_vector(const Eigen::VectorXd& pose_vector);
 
+  static Pose CreateLike(const morphac::constructs::Pose& pose);
+
  private:
   const int size_;
   Eigen::VectorXd pose_vector_;

--- a/src/morphac/constructs/include/state.h
+++ b/src/morphac/constructs/include/state.h
@@ -28,6 +28,8 @@ class State {
   State operator-(const State& state);
   State& operator*=(const double scalar);
 
+  double& operator()(const int index);
+
   bool is_empty() const;
   bool is_pose_empty() const;
   bool is_velocity_empty() const;
@@ -38,17 +40,11 @@ class State {
   const morphac::constructs::Pose& get_pose() const;
   const morphac::constructs::Velocity& get_velocity() const;
   const Eigen::VectorXd& get_pose_vector() const;
-  double get_pose_at(int index) const;
   const Eigen::VectorXd& get_velocity_vector() const;
-  double get_velocity_at(int index) const;
   const Eigen::VectorXd get_state_vector() const;
-  double get_state_at(int index) const;
   void set_pose_vector(const Eigen::VectorXd& pose_vector);
-  void set_pose_at(int index, double pose_element);
   void set_velocity_vector(const Eigen::VectorXd& velocity_vector);
-  void set_velocity_at(int index, double velocity_element);
   void set_state_vector(const Eigen::VectorXd& state_vector);
-  void set_state_at(int index, double state_element);
 
  private:
   morphac::constructs::Pose pose_;

--- a/src/morphac/constructs/include/state.h
+++ b/src/morphac/constructs/include/state.h
@@ -16,7 +16,7 @@ class State {
  public:
   // Sometimes the state may only include the poses. In such cases the velocity
   // part in the constructor may be skipped.
-  State(const int size_pose, const int size_velocity);
+  State(const int size_pose = 0, const int size_velocity = 0);
   State(const Eigen::VectorXd& pose_vector,
         const Eigen::VectorXd& velocity_vector);
   State(const morphac::constructs::Pose& pose,

--- a/src/morphac/constructs/include/state.h
+++ b/src/morphac/constructs/include/state.h
@@ -37,8 +37,8 @@ class State {
   const int get_size_pose() const;
   const int get_size_velocity() const;
   const int get_size() const;
-  const morphac::constructs::Pose& get_pose() const;
-  const morphac::constructs::Velocity& get_velocity() const;
+  morphac::constructs::Pose& get_pose();
+  morphac::constructs::Velocity& get_velocity();
   const Eigen::VectorXd& get_pose_vector() const;
   const Eigen::VectorXd& get_velocity_vector() const;
   const Eigen::VectorXd get_state_vector() const;

--- a/src/morphac/constructs/include/state.h
+++ b/src/morphac/constructs/include/state.h
@@ -29,6 +29,7 @@ class State {
   State& operator*=(const double scalar);
 
   double& operator()(const int index);
+  double operator()(const int index) const;
 
   bool is_empty() const;
   bool is_pose_empty() const;

--- a/src/morphac/constructs/include/state.h
+++ b/src/morphac/constructs/include/state.h
@@ -31,10 +31,6 @@ class State {
   double& operator()(const int index);
   double operator()(const int index) const;
 
-  bool is_empty() const;
-  bool is_pose_empty() const;
-  bool is_velocity_empty() const;
-
   const int get_size_pose() const;
   const int get_size_velocity() const;
   const int get_size() const;
@@ -52,6 +48,9 @@ class State {
   void set_velocity_vector(const Eigen::VectorXd& velocity_vector);
   void set_state_vector(const Eigen::VectorXd& state_vector);
 
+  bool IsEmpty() const;
+  bool IsPoseEmpty() const;
+  bool IsVelocityEmpty() const;
   static State CreateLike(const morphac::constructs::State& state);
 
  private:

--- a/src/morphac/constructs/include/state.h
+++ b/src/morphac/constructs/include/state.h
@@ -52,6 +52,8 @@ class State {
   void set_velocity_vector(const Eigen::VectorXd& velocity_vector);
   void set_state_vector(const Eigen::VectorXd& state_vector);
 
+  static State CreateLike(const morphac::constructs::State& state);
+
  private:
   morphac::constructs::Pose pose_;
   morphac::constructs::Velocity velocity_;

--- a/src/morphac/constructs/include/state.h
+++ b/src/morphac/constructs/include/state.h
@@ -14,11 +14,16 @@ namespace constructs {
 
 class State {
  public:
+  // Sometimes the state may only include the poses. In such cases the velocity
+  // part in the constructor may be skipped.
   State(const int size_pose, const int size_velocity);
+  State(const int size_pose);
   State(const Eigen::VectorXd& pose_vector,
         const Eigen::VectorXd& velocity_vector);
+  State(const Eigen::VectorXd& pose_vector);
   State(const morphac::constructs::Pose& pose,
         const morphac::constructs::Velocity& velocity);
+  State(const morphac::constructs::Pose& pose);
 
   State& operator+=(const State& state);
   State operator+(const State& state);

--- a/src/morphac/constructs/include/state.h
+++ b/src/morphac/constructs/include/state.h
@@ -38,8 +38,13 @@ class State {
   const int get_size_pose() const;
   const int get_size_velocity() const;
   const int get_size() const;
+
+  // Pose and Velocity accessors for const and non-const States.
   morphac::constructs::Pose& get_pose();
+  const morphac::constructs::Pose& get_pose() const;
   morphac::constructs::Velocity& get_velocity();
+  const morphac::constructs::Velocity& get_velocity() const;
+
   const Eigen::VectorXd& get_pose_vector() const;
   const Eigen::VectorXd& get_velocity_vector() const;
   const Eigen::VectorXd get_state_vector() const;

--- a/src/morphac/constructs/include/state.h
+++ b/src/morphac/constructs/include/state.h
@@ -17,19 +17,20 @@ class State {
   // Sometimes the state may only include the poses. In such cases the velocity
   // part in the constructor may be skipped.
   State(const int size_pose, const int size_velocity);
-  State(const int size_pose);
   State(const Eigen::VectorXd& pose_vector,
         const Eigen::VectorXd& velocity_vector);
-  State(const Eigen::VectorXd& pose_vector);
   State(const morphac::constructs::Pose& pose,
         const morphac::constructs::Velocity& velocity);
-  State(const morphac::constructs::Pose& pose);
 
   State& operator+=(const State& state);
   State operator+(const State& state);
   State& operator-=(const State& state);
   State operator-(const State& state);
   State& operator*=(const double scalar);
+
+  bool is_empty() const;
+  bool is_pose_empty() const;
+  bool is_velocity_empty() const;
 
   const int get_size_pose() const;
   const int get_size_velocity() const;

--- a/src/morphac/constructs/include/velocity.h
+++ b/src/morphac/constructs/include/velocity.h
@@ -20,6 +20,7 @@ class Velocity {
   Velocity& operator*=(const double scalar);
 
   double& operator()(const int index);
+  double operator()(const int index) const;
 
   bool is_empty() const;
   const int get_size() const;

--- a/src/morphac/constructs/include/velocity.h
+++ b/src/morphac/constructs/include/velocity.h
@@ -10,6 +10,7 @@ namespace constructs {
 
 class Velocity {
  public:
+  Velocity();
   Velocity(const int size);
   Velocity(const Eigen::VectorXd& velocity_vector);
 
@@ -19,6 +20,7 @@ class Velocity {
   Velocity operator-(const Velocity& velocity);
   Velocity& operator*=(const double scalar);
 
+  bool is_empty() const;
   const int get_size() const;
   const Eigen::VectorXd& get_velocity_vector() const;
   double get_velocity_at(int index) const;

--- a/src/morphac/constructs/include/velocity.h
+++ b/src/morphac/constructs/include/velocity.h
@@ -22,11 +22,11 @@ class Velocity {
   double& operator()(const int index);
   double operator()(const int index) const;
 
-  bool is_empty() const;
   const int get_size() const;
   const Eigen::VectorXd& get_velocity_vector() const;
   void set_velocity_vector(const Eigen::VectorXd& velocity_vector);
 
+  bool IsEmpty() const;
   static Velocity CreateLike(const morphac::constructs::Velocity& velocity);
 
  private:

--- a/src/morphac/constructs/include/velocity.h
+++ b/src/morphac/constructs/include/velocity.h
@@ -10,8 +10,7 @@ namespace constructs {
 
 class Velocity {
  public:
-  Velocity();
-  Velocity(const int size);
+  Velocity(const int size = 0);
   Velocity(const Eigen::VectorXd& velocity_vector);
 
   Velocity& operator+=(const Velocity& velocity);

--- a/src/morphac/constructs/include/velocity.h
+++ b/src/morphac/constructs/include/velocity.h
@@ -19,12 +19,12 @@ class Velocity {
   Velocity operator-(const Velocity& velocity);
   Velocity& operator*=(const double scalar);
 
+  double& operator()(const int index);
+
   bool is_empty() const;
   const int get_size() const;
   const Eigen::VectorXd& get_velocity_vector() const;
-  double get_velocity_at(int index) const;
   void set_velocity_vector(const Eigen::VectorXd& velocity_vector);
-  void set_velocity_at(int index, double velocity_element);
 
  private:
   const int size_;

--- a/src/morphac/constructs/include/velocity.h
+++ b/src/morphac/constructs/include/velocity.h
@@ -27,6 +27,8 @@ class Velocity {
   const Eigen::VectorXd& get_velocity_vector() const;
   void set_velocity_vector(const Eigen::VectorXd& velocity_vector);
 
+  static Velocity CreateLike(const morphac::constructs::Velocity& velocity);
+
  private:
   const int size_;
   Eigen::VectorXd velocity_vector_;

--- a/src/morphac/constructs/src/control_input.cc
+++ b/src/morphac/constructs/src/control_input.cc
@@ -5,6 +5,8 @@ namespace constructs {
 
 using Eigen::VectorXd;
 
+ControlInput::ControlInput() : size_(0), input_vector_(VectorXd::Zero(0)) {}
+
 ControlInput::ControlInput(const int size) : size_(size) {
   MORPH_REQUIRE(size > 0, std::invalid_argument,
                 "Control input size is non-positive.");
@@ -73,25 +75,32 @@ ControlInput operator*(const double scalar, ControlInput input) {
   return input *= scalar;
 }
 
+bool ControlInput::is_empty() const { return size_ == 0; }
+
 const int ControlInput::get_size() const { return size_; }
 
-const VectorXd& ControlInput::get_input_vector() const { return input_vector_; }
+const VectorXd& ControlInput::get_input_vector() const {
+  MORPH_REQUIRE(!is_empty(), std::logic_error, "Control input object is empty");
+  return input_vector_; }
 
 double ControlInput::get_input_at(int index) const {
   MORPH_REQUIRE(index >= 0 && index < size_, std::out_of_range,
                 "Control input index out of bounds.");
+  MORPH_REQUIRE(!is_empty(), std::logic_error, "Control input object is empty");
   return input_vector_(index);
 }
 
 void ControlInput::set_input_vector(const VectorXd& input_vector) {
   MORPH_REQUIRE(input_vector.size() == size_, std::invalid_argument,
                 "Control input vector size is incorrect.");
+  MORPH_REQUIRE(!is_empty(), std::logic_error, "Control input object is empty");
   input_vector_ = input_vector;
 }
 
 void ControlInput::set_input_at(int index, double input_element) {
   MORPH_REQUIRE(index >= 0 && index < size_, std::out_of_range,
                 "Control input index out of bounds.");
+  MORPH_REQUIRE(!is_empty(), std::logic_error, "Control input object is empty");
   input_vector_(index) = input_element;
 }
 

--- a/src/morphac/constructs/src/control_input.cc
+++ b/src/morphac/constructs/src/control_input.cc
@@ -73,6 +73,13 @@ ControlInput operator*(const double scalar, ControlInput input) {
   return input *= scalar;
 }
 
+double& ControlInput::operator()(const int index) {
+  MORPH_REQUIRE(index >= 0 && index < size_, std::out_of_range,
+                "Control input index out of bounds.");
+  MORPH_REQUIRE(!is_empty(), std::logic_error, "Control input object is empty");
+  return input_vector_(index);
+}
+
 bool ControlInput::is_empty() const { return size_ == 0; }
 
 const int ControlInput::get_size() const { return size_; }
@@ -82,25 +89,11 @@ const VectorXd& ControlInput::get_input_vector() const {
   return input_vector_;
 }
 
-double ControlInput::get_input_at(int index) const {
-  MORPH_REQUIRE(index >= 0 && index < size_, std::out_of_range,
-                "Control input index out of bounds.");
-  MORPH_REQUIRE(!is_empty(), std::logic_error, "Control input object is empty");
-  return input_vector_(index);
-}
-
 void ControlInput::set_input_vector(const VectorXd& input_vector) {
   MORPH_REQUIRE(input_vector.size() == size_, std::invalid_argument,
                 "Control input vector size is incorrect.");
   MORPH_REQUIRE(!is_empty(), std::logic_error, "Control input object is empty");
   input_vector_ = input_vector;
-}
-
-void ControlInput::set_input_at(int index, double input_element) {
-  MORPH_REQUIRE(index >= 0 && index < size_, std::out_of_range,
-                "Control input index out of bounds.");
-  MORPH_REQUIRE(!is_empty(), std::logic_error, "Control input object is empty");
-  input_vector_(index) = input_element;
 }
 
 }  // namespace constructs

--- a/src/morphac/constructs/src/control_input.cc
+++ b/src/morphac/constructs/src/control_input.cc
@@ -5,17 +5,15 @@ namespace constructs {
 
 using Eigen::VectorXd;
 
-ControlInput::ControlInput() : size_(0), input_vector_(VectorXd::Zero(0)) {}
-
 ControlInput::ControlInput(const int size) : size_(size) {
-  MORPH_REQUIRE(size > 0, std::invalid_argument,
+  MORPH_REQUIRE(size >= 0, std::invalid_argument,
                 "Control input size is non-positive.");
   input_vector_ = VectorXd::Zero(size);
 }
 
 ControlInput::ControlInput(const VectorXd& input_vector)
     : size_(input_vector.size()), input_vector_(input_vector) {
-  MORPH_REQUIRE(input_vector.size() > 0, std::invalid_argument,
+  MORPH_REQUIRE(input_vector.size() >= 0, std::invalid_argument,
                 "Control input vector size is non-positive.");
 }
 
@@ -81,7 +79,8 @@ const int ControlInput::get_size() const { return size_; }
 
 const VectorXd& ControlInput::get_input_vector() const {
   MORPH_REQUIRE(!is_empty(), std::logic_error, "Control input object is empty");
-  return input_vector_; }
+  return input_vector_;
+}
 
 double ControlInput::get_input_at(int index) const {
   MORPH_REQUIRE(index >= 0 && index < size_, std::out_of_range,

--- a/src/morphac/constructs/src/control_input.cc
+++ b/src/morphac/constructs/src/control_input.cc
@@ -103,6 +103,11 @@ void ControlInput::set_input_vector(const VectorXd& input_vector) {
   input_vector_ = input_vector;
 }
 
+ControlInput ControlInput::CreateLike(const ControlInput& input) {
+  ControlInput new_input{input.get_size()};
+  return new_input;
+}
+
 }  // namespace constructs
 }  // namespace morphac
 

--- a/src/morphac/constructs/src/control_input.cc
+++ b/src/morphac/constructs/src/control_input.cc
@@ -76,30 +76,30 @@ ControlInput operator*(const double scalar, ControlInput input) {
 double& ControlInput::operator()(const int index) {
   MORPH_REQUIRE(index >= 0 && index < size_, std::out_of_range,
                 "Control input index out of bounds.");
-  MORPH_REQUIRE(!is_empty(), std::logic_error, "Control input object is empty");
+  MORPH_REQUIRE(!IsEmpty(), std::logic_error, "Control input object is empty");
   return input_vector_(index);
 }
 
 double ControlInput::operator()(const int index) const {
   MORPH_REQUIRE(index >= 0 && index < size_, std::out_of_range,
                 "Control input index out of bounds.");
-  MORPH_REQUIRE(!is_empty(), std::logic_error, "Control input object is empty");
+  MORPH_REQUIRE(!IsEmpty(), std::logic_error, "Control input object is empty");
   return input_vector_(index);
 }
 
-bool ControlInput::is_empty() const { return size_ == 0; }
+bool ControlInput::IsEmpty() const { return size_ == 0; }
 
 const int ControlInput::get_size() const { return size_; }
 
 const VectorXd& ControlInput::get_input_vector() const {
-  MORPH_REQUIRE(!is_empty(), std::logic_error, "Control input object is empty");
+  MORPH_REQUIRE(!IsEmpty(), std::logic_error, "Control input object is empty");
   return input_vector_;
 }
 
 void ControlInput::set_input_vector(const VectorXd& input_vector) {
   MORPH_REQUIRE(input_vector.size() == size_, std::invalid_argument,
                 "Control input vector size is incorrect.");
-  MORPH_REQUIRE(!is_empty(), std::logic_error, "Control input object is empty");
+  MORPH_REQUIRE(!IsEmpty(), std::logic_error, "Control input object is empty");
   input_vector_ = input_vector;
 }
 

--- a/src/morphac/constructs/src/control_input.cc
+++ b/src/morphac/constructs/src/control_input.cc
@@ -80,6 +80,13 @@ double& ControlInput::operator()(const int index) {
   return input_vector_(index);
 }
 
+double ControlInput::operator()(const int index) const {
+  MORPH_REQUIRE(index >= 0 && index < size_, std::out_of_range,
+                "Control input index out of bounds.");
+  MORPH_REQUIRE(!is_empty(), std::logic_error, "Control input object is empty");
+  return input_vector_(index);
+}
+
 bool ControlInput::is_empty() const { return size_ == 0; }
 
 const int ControlInput::get_size() const { return size_; }

--- a/src/morphac/constructs/src/pose.cc
+++ b/src/morphac/constructs/src/pose.cc
@@ -67,30 +67,30 @@ Pose operator*(const double scalar, Pose pose) { return pose *= scalar; }
 double& Pose::operator()(const int index) {
   MORPH_REQUIRE(index >= 0 && index < size_, std::out_of_range,
                 "Pose index out of bounds.");
-  MORPH_REQUIRE(!is_empty(), std::logic_error, "Pose object is empty");
+  MORPH_REQUIRE(!IsEmpty(), std::logic_error, "Pose object is empty");
   return pose_vector_(index);
 }
 
 double Pose::operator()(const int index) const {
   MORPH_REQUIRE(index >= 0 && index < size_, std::out_of_range,
                 "Pose index out of bounds.");
-  MORPH_REQUIRE(!is_empty(), std::logic_error, "Pose object is empty");
+  MORPH_REQUIRE(!IsEmpty(), std::logic_error, "Pose object is empty");
   return pose_vector_(index);
 }
 
-bool Pose::is_empty() const { return size_ == 0; }
+bool Pose::IsEmpty() const { return size_ == 0; }
 
 const int Pose::get_size() const { return size_; }
 
 const VectorXd& Pose::get_pose_vector() const {
-  MORPH_REQUIRE(!is_empty(), std::logic_error, "Pose object is empty");
+  MORPH_REQUIRE(!IsEmpty(), std::logic_error, "Pose object is empty");
   return pose_vector_;
 }
 
 void Pose::set_pose_vector(const VectorXd& pose_vector) {
   MORPH_REQUIRE(pose_vector.size() == size_, std::invalid_argument,
                 "Pose vector size is incorrect.");
-  MORPH_REQUIRE(!is_empty(), std::logic_error, "Pose object is empty");
+  MORPH_REQUIRE(!IsEmpty(), std::logic_error, "Pose object is empty");
   pose_vector_ = pose_vector;
 }
 

--- a/src/morphac/constructs/src/pose.cc
+++ b/src/morphac/constructs/src/pose.cc
@@ -71,6 +71,13 @@ double& Pose::operator()(const int index) {
   return pose_vector_(index);
 }
 
+double Pose::operator()(const int index) const {
+  MORPH_REQUIRE(index >= 0 && index < size_, std::out_of_range,
+                "Pose index out of bounds.");
+  MORPH_REQUIRE(!is_empty(), std::logic_error, "Pose object is empty");
+  return pose_vector_(index);
+}
+
 bool Pose::is_empty() const { return size_ == 0; }
 
 const int Pose::get_size() const { return size_; }

--- a/src/morphac/constructs/src/pose.cc
+++ b/src/morphac/constructs/src/pose.cc
@@ -94,6 +94,11 @@ void Pose::set_pose_vector(const VectorXd& pose_vector) {
   pose_vector_ = pose_vector;
 }
 
+Pose Pose::CreateLike(const Pose& pose) {
+  Pose new_pose{pose.get_size()};
+  return new_pose;
+}
+
 }  // namespace constructs
 }  // namespace morphac
 

--- a/src/morphac/constructs/src/pose.cc
+++ b/src/morphac/constructs/src/pose.cc
@@ -5,6 +5,8 @@ namespace constructs {
 
 using Eigen::VectorXd;
 
+Pose::Pose() : size_(0), pose_vector_(Eigen::VectorXd::Zero(0)) {}
+
 Pose::Pose(const int size) : size_(size) {
   MORPH_REQUIRE(size > 0, std::invalid_argument, "Pose size is non-positive.");
   pose_vector_ = VectorXd::Zero(size);
@@ -60,34 +62,37 @@ Pose& Pose::operator*=(const double scalar) {
 }
 
 // Non-member multiplication functions
-Pose operator*(Pose pose, const double scalar) {
-  return pose*=scalar;
-}
+Pose operator*(Pose pose, const double scalar) { return pose *= scalar; }
 
-Pose operator*(const double scalar, Pose pose) {
-  return pose*=scalar;
-}
+Pose operator*(const double scalar, Pose pose) { return pose *= scalar; }
 
+bool Pose::is_empty() const { return size_ == 0; }
 
 const int Pose::get_size() const { return size_; }
 
-const VectorXd& Pose::get_pose_vector() const { return pose_vector_; }
+const VectorXd& Pose::get_pose_vector() const {
+  MORPH_REQUIRE(!is_empty(), std::logic_error, "Pose object is empty");
+  return pose_vector_;
+}
 
 double Pose::get_pose_at(int index) const {
   MORPH_REQUIRE(index >= 0 && index < size_, std::out_of_range,
                 "Pose index out of bounds.");
+  MORPH_REQUIRE(!is_empty(), std::logic_error, "Pose object is empty");
   return pose_vector_(index);
 }
 
 void Pose::set_pose_vector(const VectorXd& pose_vector) {
   MORPH_REQUIRE(pose_vector.size() == size_, std::invalid_argument,
                 "Pose vector size is incorrect.");
+  MORPH_REQUIRE(!is_empty(), std::logic_error, "Pose object is empty");
   pose_vector_ = pose_vector;
 }
 
 void Pose::set_pose_at(int index, double pose_element) {
   MORPH_REQUIRE(index >= 0 && index < size_, std::out_of_range,
                 "Pose index out of bounds.");
+  MORPH_REQUIRE(!is_empty(), std::logic_error, "Pose object is empty");
   pose_vector_(index) = pose_element;
 }
 

--- a/src/morphac/constructs/src/pose.cc
+++ b/src/morphac/constructs/src/pose.cc
@@ -5,16 +5,14 @@ namespace constructs {
 
 using Eigen::VectorXd;
 
-Pose::Pose() : size_(0), pose_vector_(Eigen::VectorXd::Zero(0)) {}
-
 Pose::Pose(const int size) : size_(size) {
-  MORPH_REQUIRE(size > 0, std::invalid_argument, "Pose size is non-positive.");
+  MORPH_REQUIRE(size >= 0, std::invalid_argument, "Pose size is non-positive.");
   pose_vector_ = VectorXd::Zero(size);
 }
 
 Pose::Pose(const VectorXd& pose_vector)
     : size_(pose_vector.size()), pose_vector_(pose_vector) {
-  MORPH_REQUIRE(pose_vector.size() > 0, std::invalid_argument,
+  MORPH_REQUIRE(pose_vector.size() >= 0, std::invalid_argument,
                 "Pose vector size is non-positive.");
 }
 

--- a/src/morphac/constructs/src/pose.cc
+++ b/src/morphac/constructs/src/pose.cc
@@ -64,6 +64,13 @@ Pose operator*(Pose pose, const double scalar) { return pose *= scalar; }
 
 Pose operator*(const double scalar, Pose pose) { return pose *= scalar; }
 
+double& Pose::operator()(const int index) {
+  MORPH_REQUIRE(index >= 0 && index < size_, std::out_of_range,
+                "Pose index out of bounds.");
+  MORPH_REQUIRE(!is_empty(), std::logic_error, "Pose object is empty");
+  return pose_vector_(index);
+}
+
 bool Pose::is_empty() const { return size_ == 0; }
 
 const int Pose::get_size() const { return size_; }
@@ -73,25 +80,11 @@ const VectorXd& Pose::get_pose_vector() const {
   return pose_vector_;
 }
 
-double Pose::get_pose_at(int index) const {
-  MORPH_REQUIRE(index >= 0 && index < size_, std::out_of_range,
-                "Pose index out of bounds.");
-  MORPH_REQUIRE(!is_empty(), std::logic_error, "Pose object is empty");
-  return pose_vector_(index);
-}
-
 void Pose::set_pose_vector(const VectorXd& pose_vector) {
   MORPH_REQUIRE(pose_vector.size() == size_, std::invalid_argument,
                 "Pose vector size is incorrect.");
   MORPH_REQUIRE(!is_empty(), std::logic_error, "Pose object is empty");
   pose_vector_ = pose_vector;
-}
-
-void Pose::set_pose_at(int index, double pose_element) {
-  MORPH_REQUIRE(index >= 0 && index < size_, std::out_of_range,
-                "Pose index out of bounds.");
-  MORPH_REQUIRE(!is_empty(), std::logic_error, "Pose object is empty");
-  pose_vector_(index) = pose_element;
 }
 
 }  // namespace constructs

--- a/src/morphac/constructs/src/state.cc
+++ b/src/morphac/constructs/src/state.cc
@@ -169,7 +169,11 @@ const int State::get_size() const {
 
 Pose& State::get_pose() { return pose_; }
 
+const Pose& State::get_pose() const { return pose_; }
+
 Velocity& State::get_velocity() { return velocity_; }
+
+const Velocity& State::get_velocity() const { return velocity_; }
 
 const VectorXd& State::get_pose_vector() const {
   return pose_.get_pose_vector();

--- a/src/morphac/constructs/src/state.cc
+++ b/src/morphac/constructs/src/state.cc
@@ -127,6 +127,19 @@ State operator*(State state, const double scalar) { return state *= scalar; }
 
 State operator*(const double scalar, State state) { return state *= scalar; }
 
+double& State::operator()(const int index) {
+  MORPH_REQUIRE(index >= 0 && index < get_size(), std::out_of_range,
+                "Pose index out of bounds.");
+  MORPH_REQUIRE(!is_empty(), std::logic_error, "State object is empty");
+  // If the index corresponds to the pose
+  if (index < get_size_pose()) {
+    return pose_(index);
+  } else {
+    // Index corresponds to velocity
+    return velocity_(index - get_size_pose());
+  }
+}
+
 bool State::is_empty() const { return is_pose_empty() && is_velocity_empty(); }
 
 bool State::is_pose_empty() const { return pose_.is_empty(); }
@@ -141,26 +154,16 @@ const int State::get_size() const {
   return pose_.get_size() + velocity_.get_size();
 }
 
-const Pose& State::get_pose() const { return pose_; }
+Pose& State::get_pose() { return pose_; }
 
-const Velocity& State::get_velocity() const { return velocity_; }
+Velocity& State::get_velocity() { return velocity_; }
 
 const VectorXd& State::get_pose_vector() const {
   return pose_.get_pose_vector();
 }
 
-double State::get_pose_at(int index) const {
-  // The Pose class getter does the argument check.
-  return pose_.get_pose_at(index);
-}
-
 const VectorXd& State::get_velocity_vector() const {
   return velocity_.get_velocity_vector();
-}
-
-double State::get_velocity_at(int index) const {
-  // The Velocity class getter does the argument check.
-  return velocity_.get_velocity_at(index);
 }
 
 const VectorXd State::get_state_vector() const {
@@ -169,34 +172,14 @@ const VectorXd State::get_state_vector() const {
   return state_vector;
 }
 
-double State::get_state_at(int index) const {
-  // If the index corresponds to the pose
-  if (index < get_size_pose()) {
-    return get_pose_at(index);
-  } else {
-    // Index corresponds to velocity
-    return get_velocity_at(index - get_size_pose());
-  }
-}
-
 void State::set_pose_vector(const VectorXd& pose_vector) {
   // The Pose class setter does the argument check.
   pose_.set_pose_vector(pose_vector);
 }
 
-void State::set_pose_at(int index, double pose_element) {
-  // The Pose class setter does the argument check.
-  pose_.set_pose_at(index, pose_element);
-}
-
 void State::set_velocity_vector(const VectorXd& velocity_vector) {
   // The Velocity class getter does the argument check.
   velocity_.set_velocity_vector(velocity_vector);
-}
-
-void State::set_velocity_at(int index, double velocity_element) {
-  // The Velocity class getter does the argument check.
-  velocity_.set_velocity_at(index, velocity_element);
 }
 
 void State::set_state_vector(const VectorXd& state_vector) {
@@ -205,15 +188,6 @@ void State::set_state_vector(const VectorXd& state_vector) {
                 "State vector size is incorrect.");
   set_pose_vector(state_vector.head(get_size_pose()));
   set_velocity_vector(state_vector.tail(get_size_velocity()));
-}
-
-void State::set_state_at(int index, double state_element) {
-  // The Pose and Velocity class takes care of the argument check
-  if (index < get_size_pose()) {
-    set_pose_at(index, state_element);
-  } else {
-    set_velocity_at(index - get_size_pose(), state_element);
-  }
 }
 
 }  // constructs

--- a/src/morphac/constructs/src/state.cc
+++ b/src/morphac/constructs/src/state.cc
@@ -36,10 +36,10 @@ State& State::operator+=(const State& state) {
   // The pose and velocities are added and set if they are non empty. If they
   // are empty, the default empty objects are kept as is and the resulting
   // pose/vector is also empty.
-  if (!is_pose_empty()) {
+  if (!IsPoseEmpty()) {
     this->set_pose_vector(this->get_pose_vector() + state.get_pose_vector());
   }
-  if (!is_velocity_empty()) {
+  if (!IsVelocityEmpty()) {
     this->set_velocity_vector(this->get_velocity_vector() +
                               state.get_velocity_vector());
   }
@@ -57,10 +57,10 @@ State State::operator+(const State& state) {
   // The pose and velocities are added and set if they are non empty. If they
   // are empty, the default empty objects are kept as is and the resulting
   // pose/vector is also empty.
-  if (!is_pose_empty()) {
+  if (!IsPoseEmpty()) {
     result.set_pose_vector(this->get_pose_vector() + state.get_pose_vector());
   }
-  if (!is_velocity_empty()) {
+  if (!IsVelocityEmpty()) {
     result.set_velocity_vector(this->get_velocity_vector() +
                                state.get_velocity_vector());
   }
@@ -78,10 +78,10 @@ State& State::operator-=(const State& state) {
   // The pose and velocities are subtracted and set if they are non empty. If
   // they are empty, the default empty objects are kept as is and the resulting
   // pose/vector is also empty.
-  if (!is_pose_empty()) {
+  if (!IsPoseEmpty()) {
     this->set_pose_vector(this->get_pose_vector() - state.get_pose_vector());
   }
-  if (!is_velocity_empty()) {
+  if (!IsVelocityEmpty()) {
     this->set_velocity_vector(this->get_velocity_vector() -
                               state.get_velocity_vector());
   }
@@ -99,10 +99,10 @@ State State::operator-(const State& state) {
   // The pose and velocities are subtracted and set if they are non empty. If
   // they are empty, the default empty objects are kept as is and the resulting
   // pose/vector is also empty.
-  if (!is_pose_empty()) {
+  if (!IsPoseEmpty()) {
     result.set_pose_vector(this->get_pose_vector() - state.get_pose_vector());
   }
-  if (!is_velocity_empty()) {
+  if (!IsVelocityEmpty()) {
     result.set_velocity_vector(this->get_velocity_vector() -
                                state.get_velocity_vector());
   }
@@ -113,10 +113,10 @@ State& State::operator*=(const double scalar) {
   // The pose and velocities are multiplied and set if they are non empty. If
   // they are empty, the default empty objects are kept as is and the resulting
   // pose/vector is also empty.
-  if (!is_pose_empty()) {
+  if (!IsPoseEmpty()) {
     this->set_pose_vector(this->get_pose_vector() * scalar);
   }
-  if (!is_velocity_empty()) {
+  if (!IsVelocityEmpty()) {
     this->set_velocity_vector(this->get_velocity_vector() * scalar);
   }
   return *this;
@@ -130,7 +130,7 @@ State operator*(const double scalar, State state) { return state *= scalar; }
 double& State::operator()(const int index) {
   MORPH_REQUIRE(index >= 0 && index < get_size(), std::out_of_range,
                 "Pose index out of bounds.");
-  MORPH_REQUIRE(!is_empty(), std::logic_error, "State object is empty");
+  MORPH_REQUIRE(!IsEmpty(), std::logic_error, "State object is empty");
   // If the index corresponds to the pose
   if (index < get_size_pose()) {
     return pose_(index);
@@ -143,7 +143,7 @@ double& State::operator()(const int index) {
 double State::operator()(const int index) const {
   MORPH_REQUIRE(index >= 0 && index < get_size(), std::out_of_range,
                 "Pose index out of bounds.");
-  MORPH_REQUIRE(!is_empty(), std::logic_error, "State object is empty");
+  MORPH_REQUIRE(!IsEmpty(), std::logic_error, "State object is empty");
   // If the index corresponds to the pose
   if (index < get_size_pose()) {
     return pose_(index);
@@ -153,11 +153,11 @@ double State::operator()(const int index) const {
   }
 }
 
-bool State::is_empty() const { return is_pose_empty() && is_velocity_empty(); }
+bool State::IsEmpty() const { return IsPoseEmpty() && IsVelocityEmpty(); }
 
-bool State::is_pose_empty() const { return pose_.is_empty(); }
+bool State::IsPoseEmpty() const { return pose_.IsEmpty(); }
 
-bool State::is_velocity_empty() const { return velocity_.is_empty(); }
+bool State::IsVelocityEmpty() const { return velocity_.IsEmpty(); }
 
 const int State::get_size_pose() const { return pose_.get_size(); }
 
@@ -184,8 +184,19 @@ const VectorXd& State::get_velocity_vector() const {
 }
 
 const VectorXd State::get_state_vector() const {
+  MORPH_REQUIRE(!IsEmpty(), std::logic_error, "State object is empty");
   VectorXd state_vector(get_size());
-  state_vector << get_pose_vector(), get_velocity_vector();
+  VectorXd pose_vector = VectorXd::Zero(0);
+  VectorXd velocity_vector = VectorXd::Zero(0);
+
+  // Populating if not empty.
+  if (!IsPoseEmpty()) {
+    pose_vector = get_pose_vector();
+  }
+  if (!IsVelocityEmpty()) {
+    velocity_vector = get_velocity_vector();
+  }
+  state_vector << pose_vector, velocity_vector;
   return state_vector;
 }
 
@@ -203,8 +214,13 @@ void State::set_state_vector(const VectorXd& state_vector) {
   // Need to check if the dimensions are correct
   MORPH_REQUIRE(state_vector.size() == get_size(), std::invalid_argument,
                 "State vector size is incorrect.");
-  set_pose_vector(state_vector.head(get_size_pose()));
-  set_velocity_vector(state_vector.tail(get_size_velocity()));
+  MORPH_REQUIRE(!IsEmpty(), std::logic_error, "State object is empty");
+  if (!IsPoseEmpty()) {
+    set_pose_vector(state_vector.head(get_size_pose()));
+  }
+  if (!IsVelocityEmpty()) {
+    set_velocity_vector(state_vector.tail(get_size_velocity()));
+  }
 }
 
 State State::CreateLike(const State& state) {

--- a/src/morphac/constructs/src/state.cc
+++ b/src/morphac/constructs/src/state.cc
@@ -207,5 +207,10 @@ void State::set_state_vector(const VectorXd& state_vector) {
   set_velocity_vector(state_vector.tail(get_size_velocity()));
 }
 
+State State::CreateLike(const State& state) {
+  State new_state{state.get_size_pose(), state.get_size_velocity()};
+  return new_state;
+}
+
 }  // constructs
 }  // morphac

--- a/src/morphac/constructs/src/state.cc
+++ b/src/morphac/constructs/src/state.cc
@@ -140,6 +140,19 @@ double& State::operator()(const int index) {
   }
 }
 
+double State::operator()(const int index) const {
+  MORPH_REQUIRE(index >= 0 && index < get_size(), std::out_of_range,
+                "Pose index out of bounds.");
+  MORPH_REQUIRE(!is_empty(), std::logic_error, "State object is empty");
+  // If the index corresponds to the pose
+  if (index < get_size_pose()) {
+    return pose_(index);
+  } else {
+    // Index corresponds to velocity
+    return velocity_(index - get_size_pose());
+  }
+}
+
 bool State::is_empty() const { return is_pose_empty() && is_velocity_empty(); }
 
 bool State::is_pose_empty() const { return pose_.is_empty(); }

--- a/src/morphac/constructs/src/state.cc
+++ b/src/morphac/constructs/src/state.cc
@@ -17,22 +17,13 @@ State::State(const int size_pose, const int size_velocity)
   // The Pose and Velocity constructors take care of invalid arguments.
 }
 
-State::State(const int size_pose)
-    : pose_(Pose(size_pose)), velocity_(Velocity()) {}
-
 State::State(const VectorXd& pose_vector, const VectorXd& velocity_vector)
     : pose_(Pose(pose_vector)), velocity_(Velocity(velocity_vector)) {
   // The Pose and Velocity constructors take care of invalid arguments.
 }
 
-State::State(const VectorXd& pose_vector)
-    : pose_(Pose(pose_vector)), velocity_(Velocity()) {}
-
 State::State(const Pose& pose, const Velocity& velocity)
     : pose_(pose), velocity_(velocity) {}
-
-State::State(const Pose& pose)
-    : pose_(pose), velocity_(Velocity()) {}
 
 State& State::operator+=(const State& state) {
   MORPH_REQUIRE(
@@ -42,9 +33,16 @@ State& State::operator+=(const State& state) {
       "States are not of the same size. The += operator requires them "
       "to be of the "
       "same size.");
-  this->set_pose_vector(this->get_pose_vector() + state.get_pose_vector());
-  this->set_velocity_vector(this->get_velocity_vector() +
-                            state.get_velocity_vector());
+  // The pose and velocities are added and set if they are non empty. If they
+  // are empty, the default empty objects are kept as is and the resulting
+  // pose/vector is also empty.
+  if (!is_pose_empty()) {
+    this->set_pose_vector(this->get_pose_vector() + state.get_pose_vector());
+  }
+  if (!is_velocity_empty()) {
+    this->set_velocity_vector(this->get_velocity_vector() +
+                              state.get_velocity_vector());
+  }
   return *this;
 }
 
@@ -56,9 +54,16 @@ State State::operator+(const State& state) {
                 "to be of the "
                 "same size.");
   State result(this->get_size_pose(), this->get_size_velocity());
-  result.set_pose_vector(this->get_pose_vector() + state.get_pose_vector());
-  result.set_velocity_vector(this->get_velocity_vector() +
-                             state.get_velocity_vector());
+  // The pose and velocities are added and set if they are non empty. If they
+  // are empty, the default empty objects are kept as is and the resulting
+  // pose/vector is also empty.
+  if (!is_pose_empty()) {
+    result.set_pose_vector(this->get_pose_vector() + state.get_pose_vector());
+  }
+  if (!is_velocity_empty()) {
+    result.set_velocity_vector(this->get_velocity_vector() +
+                               state.get_velocity_vector());
+  }
   return result;
 }
 
@@ -70,9 +75,16 @@ State& State::operator-=(const State& state) {
       "States are not of the same size. The -= operator requires them "
       "to be of the "
       "same size.");
-  this->set_pose_vector(this->get_pose_vector() - state.get_pose_vector());
-  this->set_velocity_vector(this->get_velocity_vector() -
-                            state.get_velocity_vector());
+  // The pose and velocities are subtracted and set if they are non empty. If
+  // they are empty, the default empty objects are kept as is and the resulting
+  // pose/vector is also empty.
+  if (!is_pose_empty()) {
+    this->set_pose_vector(this->get_pose_vector() - state.get_pose_vector());
+  }
+  if (!is_velocity_empty()) {
+    this->set_velocity_vector(this->get_velocity_vector() -
+                              state.get_velocity_vector());
+  }
   return *this;
 }
 
@@ -84,15 +96,29 @@ State State::operator-(const State& state) {
                 "to be of the "
                 "same size.");
   State result(this->get_size_pose(), this->get_size_velocity());
-  result.set_pose_vector(this->get_pose_vector() - state.get_pose_vector());
-  result.set_velocity_vector(this->get_velocity_vector() -
-                             state.get_velocity_vector());
+  // The pose and velocities are subtracted and set if they are non empty. If
+  // they are empty, the default empty objects are kept as is and the resulting
+  // pose/vector is also empty.
+  if (!is_pose_empty()) {
+    result.set_pose_vector(this->get_pose_vector() - state.get_pose_vector());
+  }
+  if (!is_velocity_empty()) {
+    result.set_velocity_vector(this->get_velocity_vector() -
+                               state.get_velocity_vector());
+  }
   return result;
 }
 
 State& State::operator*=(const double scalar) {
-  this->set_pose_vector(this->get_pose_vector() * scalar);
-  this->set_velocity_vector(this->get_velocity_vector() * scalar);
+  // The pose and velocities are multiplied and set if they are non empty. If
+  // they are empty, the default empty objects are kept as is and the resulting
+  // pose/vector is also empty.
+  if (!is_pose_empty()) {
+    this->set_pose_vector(this->get_pose_vector() * scalar);
+  }
+  if (!is_velocity_empty()) {
+    this->set_velocity_vector(this->get_velocity_vector() * scalar);
+  }
   return *this;
 }
 
@@ -100,6 +126,12 @@ State& State::operator*=(const double scalar) {
 State operator*(State state, const double scalar) { return state *= scalar; }
 
 State operator*(const double scalar, State state) { return state *= scalar; }
+
+bool State::is_empty() const { return is_pose_empty() && is_velocity_empty(); }
+
+bool State::is_pose_empty() const { return pose_.is_empty(); }
+
+bool State::is_velocity_empty() const { return velocity_.is_empty(); }
 
 const int State::get_size_pose() const { return pose_.get_size(); }
 

--- a/src/morphac/constructs/src/state.cc
+++ b/src/morphac/constructs/src/state.cc
@@ -17,13 +17,22 @@ State::State(const int size_pose, const int size_velocity)
   // The Pose and Velocity constructors take care of invalid arguments.
 }
 
+State::State(const int size_pose)
+    : pose_(Pose(size_pose)), velocity_(Velocity()) {}
+
 State::State(const VectorXd& pose_vector, const VectorXd& velocity_vector)
     : pose_(Pose(pose_vector)), velocity_(Velocity(velocity_vector)) {
   // The Pose and Velocity constructors take care of invalid arguments.
 }
 
+State::State(const VectorXd& pose_vector)
+    : pose_(Pose(pose_vector)), velocity_(Velocity()) {}
+
 State::State(const Pose& pose, const Velocity& velocity)
     : pose_(pose), velocity_(velocity) {}
+
+State::State(const Pose& pose)
+    : pose_(pose), velocity_(Velocity()) {}
 
 State& State::operator+=(const State& state) {
   MORPH_REQUIRE(

--- a/src/morphac/constructs/src/velocity.cc
+++ b/src/morphac/constructs/src/velocity.cc
@@ -73,6 +73,13 @@ Velocity operator*(const double scalar, Velocity velocity) {
   return velocity *= scalar;
 }
 
+double& Velocity::operator()(const int index) {
+  MORPH_REQUIRE(index >= 0 && index < size_, std::out_of_range,
+                "Velocity index out of bounds.");
+  MORPH_REQUIRE(!is_empty(), std::logic_error, "Velocity object is empty");
+  return velocity_vector_(index);
+}
+
 bool Velocity::is_empty() const { return size_ == 0; }
 
 const int Velocity::get_size() const { return size_; }
@@ -82,25 +89,11 @@ const VectorXd& Velocity::get_velocity_vector() const {
   return velocity_vector_;
 }
 
-double Velocity::get_velocity_at(int index) const {
-  MORPH_REQUIRE(index >= 0 && index < size_, std::out_of_range,
-                "Velocity index out of bounds.");
-  MORPH_REQUIRE(!is_empty(), std::logic_error, "Velocity object is empty");
-  return velocity_vector_(index);
-}
-
 void Velocity::set_velocity_vector(const VectorXd& velocity_vector) {
   MORPH_REQUIRE(velocity_vector.size() == size_, std::invalid_argument,
                 "Velocity vector size is incorrect.");
   MORPH_REQUIRE(!is_empty(), std::logic_error, "Velocity object is empty");
   velocity_vector_ = velocity_vector;
-}
-
-void Velocity::set_velocity_at(int index, double velocity_element) {
-  MORPH_REQUIRE(index >= 0 && index < size_, std::out_of_range,
-                "Velocity index out of bounds.");
-  MORPH_REQUIRE(!is_empty(), std::logic_error, "Velocity object is empty");
-  velocity_vector_(index) = velocity_element;
 }
 
 }  // namespace constructs

--- a/src/morphac/constructs/src/velocity.cc
+++ b/src/morphac/constructs/src/velocity.cc
@@ -5,6 +5,8 @@ namespace constructs {
 
 using Eigen::VectorXd;
 
+Velocity::Velocity() : size_(0), velocity_vector_(Eigen::VectorXd::Zero(0)) {}
+
 Velocity::Velocity(const int size) : size_(size) {
   MORPH_REQUIRE(size > 0, std::invalid_argument,
                 "Velocity size is non-positive.");
@@ -73,27 +75,33 @@ Velocity operator*(const double scalar, Velocity velocity) {
   return velocity *= scalar;
 }
 
+bool Velocity::is_empty() const { return size_ == 0; }
+
 const int Velocity::get_size() const { return size_; }
 
 const VectorXd& Velocity::get_velocity_vector() const {
+  MORPH_REQUIRE(!is_empty(), std::logic_error, "Velocity object is empty");
   return velocity_vector_;
 }
 
 double Velocity::get_velocity_at(int index) const {
   MORPH_REQUIRE(index >= 0 && index < size_, std::out_of_range,
                 "Velocity index out of bounds.");
+  MORPH_REQUIRE(!is_empty(), std::logic_error, "Velocity object is empty");
   return velocity_vector_(index);
 }
 
 void Velocity::set_velocity_vector(const VectorXd& velocity_vector) {
   MORPH_REQUIRE(velocity_vector.size() == size_, std::invalid_argument,
                 "Velocity vector size is incorrect.");
+  MORPH_REQUIRE(!is_empty(), std::logic_error, "Velocity object is empty");
   velocity_vector_ = velocity_vector;
 }
 
 void Velocity::set_velocity_at(int index, double velocity_element) {
   MORPH_REQUIRE(index >= 0 && index < size_, std::out_of_range,
                 "Velocity index out of bounds.");
+  MORPH_REQUIRE(!is_empty(), std::logic_error, "Velocity object is empty");
   velocity_vector_(index) = velocity_element;
 }
 

--- a/src/morphac/constructs/src/velocity.cc
+++ b/src/morphac/constructs/src/velocity.cc
@@ -103,6 +103,11 @@ void Velocity::set_velocity_vector(const VectorXd& velocity_vector) {
   velocity_vector_ = velocity_vector;
 }
 
+Velocity Velocity::CreateLike(const Velocity& velocity) {
+  Velocity new_velocity{velocity.get_size()};
+  return new_velocity;
+}
+
 }  // namespace constructs
 }  // namespace morphac
 

--- a/src/morphac/constructs/src/velocity.cc
+++ b/src/morphac/constructs/src/velocity.cc
@@ -80,6 +80,13 @@ double& Velocity::operator()(const int index) {
   return velocity_vector_(index);
 }
 
+double Velocity::operator()(const int index) const {
+  MORPH_REQUIRE(index >= 0 && index < size_, std::out_of_range,
+                "Velocity index out of bounds.");
+  MORPH_REQUIRE(!is_empty(), std::logic_error, "Velocity object is empty");
+  return velocity_vector_(index);
+}
+
 bool Velocity::is_empty() const { return size_ == 0; }
 
 const int Velocity::get_size() const { return size_; }

--- a/src/morphac/constructs/src/velocity.cc
+++ b/src/morphac/constructs/src/velocity.cc
@@ -5,7 +5,7 @@ namespace constructs {
 
 using Eigen::VectorXd;
 
-Velocity::Velocity() : size_(0), velocity_vector_(Eigen::VectorXd::Zero(0)) {}
+Velocity::Velocity() : size_(0), velocity_vector_(VectorXd::Zero(0)) {}
 
 Velocity::Velocity(const int size) : size_(size) {
   MORPH_REQUIRE(size > 0, std::invalid_argument,

--- a/src/morphac/constructs/src/velocity.cc
+++ b/src/morphac/constructs/src/velocity.cc
@@ -5,17 +5,15 @@ namespace constructs {
 
 using Eigen::VectorXd;
 
-Velocity::Velocity() : size_(0), velocity_vector_(VectorXd::Zero(0)) {}
-
 Velocity::Velocity(const int size) : size_(size) {
-  MORPH_REQUIRE(size > 0, std::invalid_argument,
+  MORPH_REQUIRE(size >= 0, std::invalid_argument,
                 "Velocity size is non-positive.");
   velocity_vector_ = VectorXd::Zero(size);
 }
 
 Velocity::Velocity(const VectorXd& velocity_vector)
     : size_(velocity_vector.size()), velocity_vector_(velocity_vector) {
-  MORPH_REQUIRE(velocity_vector.size() > 0, std::invalid_argument,
+  MORPH_REQUIRE(velocity_vector.size() >= 0, std::invalid_argument,
                 "Velocity vector size is non-positive.");
 }
 

--- a/src/morphac/constructs/src/velocity.cc
+++ b/src/morphac/constructs/src/velocity.cc
@@ -76,30 +76,30 @@ Velocity operator*(const double scalar, Velocity velocity) {
 double& Velocity::operator()(const int index) {
   MORPH_REQUIRE(index >= 0 && index < size_, std::out_of_range,
                 "Velocity index out of bounds.");
-  MORPH_REQUIRE(!is_empty(), std::logic_error, "Velocity object is empty");
+  MORPH_REQUIRE(!IsEmpty(), std::logic_error, "Velocity object is empty");
   return velocity_vector_(index);
 }
 
 double Velocity::operator()(const int index) const {
   MORPH_REQUIRE(index >= 0 && index < size_, std::out_of_range,
                 "Velocity index out of bounds.");
-  MORPH_REQUIRE(!is_empty(), std::logic_error, "Velocity object is empty");
+  MORPH_REQUIRE(!IsEmpty(), std::logic_error, "Velocity object is empty");
   return velocity_vector_(index);
 }
 
-bool Velocity::is_empty() const { return size_ == 0; }
+bool Velocity::IsEmpty() const { return size_ == 0; }
 
 const int Velocity::get_size() const { return size_; }
 
 const VectorXd& Velocity::get_velocity_vector() const {
-  MORPH_REQUIRE(!is_empty(), std::logic_error, "Velocity object is empty");
+  MORPH_REQUIRE(!IsEmpty(), std::logic_error, "Velocity object is empty");
   return velocity_vector_;
 }
 
 void Velocity::set_velocity_vector(const VectorXd& velocity_vector) {
   MORPH_REQUIRE(velocity_vector.size() == size_, std::invalid_argument,
                 "Velocity vector size is incorrect.");
-  MORPH_REQUIRE(!is_empty(), std::logic_error, "Velocity object is empty");
+  MORPH_REQUIRE(!IsEmpty(), std::logic_error, "Velocity object is empty");
   velocity_vector_ = velocity_vector;
 }
 

--- a/src/morphac/constructs/test/control_input_test.cc
+++ b/src/morphac/constructs/test/control_input_test.cc
@@ -160,6 +160,17 @@ TEST_F(ControlInputTest, EmptyControlInputOperations) {
   ASSERT_TRUE(input_mult.is_empty());
 }
 
+TEST_F(ControlInputTest, CreateLike) {
+  ControlInput input1 = ControlInput::CreateLike(input1_);
+  ControlInput input2 = ControlInput::CreateLike(input3_);
+
+  ASSERT_EQ(input1.get_size(), 3);
+  ASSERT_TRUE(input1.get_input_vector().isApprox(VectorXd::Zero(3)));
+
+  ASSERT_EQ(input2.get_size(), 6);
+  ASSERT_TRUE(input2.get_input_vector().isApprox(VectorXd::Zero(6)));
+}
+
 }  // namespace
 
 int main(int argc, char **argv) {

--- a/src/morphac/constructs/test/control_input_test.cc
+++ b/src/morphac/constructs/test/control_input_test.cc
@@ -52,6 +52,14 @@ TEST_F(ControlInputTest, SetInput) {
   ASSERT_TRUE(input3_.get_input_vector().isApprox(v));
 }
 
+TEST_F(ControlInputTest, ConstInputGet) {
+  const ControlInput input{3};
+
+  // For a const ControlInput, the values can only be accessed but not set, as a
+  // reference (lvalue) is not returned for this overload of the operator.
+  ASSERT_EQ(input(0), 0);
+}
+
 TEST_F(ControlInputTest, InvalidConstruction) {
   ASSERT_THROW(ControlInput{-1}, std::invalid_argument);
 }

--- a/src/morphac/constructs/test/control_input_test.cc
+++ b/src/morphac/constructs/test/control_input_test.cc
@@ -40,14 +40,16 @@ TEST_F(ControlInputTest, SetControlInput) {
 }
 
 TEST_F(ControlInputTest, InvalidConstruction) {
-  ASSERT_THROW(ControlInput(0), std::invalid_argument);
-  ASSERT_THROW(ControlInput(VectorXd::Random(0)), std::invalid_argument);
+  ASSERT_THROW(ControlInput{-1}, std::invalid_argument);
 }
 
 TEST_F(ControlInputTest, EmptyConstruction) {
   ControlInput input;
 
-  // Accessors are invalid for empty velocity
+  // Assert emptiness
+  ASSERT_TRUE(input.is_empty());
+
+  // Accessors are invalid for empty ControlInput
   ASSERT_THROW(input.get_input_vector(), std::logic_error);
   ASSERT_THROW(input.get_input_at(0), std::logic_error);
   ASSERT_THROW(input.set_input_vector(VectorXd::Random(0)), std::logic_error);
@@ -75,8 +77,8 @@ TEST_F(ControlInputTest, Addition) {
   d1 << 5, 7, 9;
   d2 << 9, 12, 15;
 
-  ControlInput input1(i1);
-  ControlInput input2(i2);
+  ControlInput input1{i1};
+  ControlInput input2{i2};
   input1 += input2;
   ASSERT_TRUE(input1.get_input_vector().isApprox(d1));
 
@@ -94,8 +96,8 @@ TEST_F(ControlInputTest, Subtraction) {
   d1 << -3, -3, -3;
   d2 << -7, -8, -9;
 
-  ControlInput input1(i1);
-  ControlInput input2(i2);
+  ControlInput input1{i1};
+  ControlInput input2{i2};
   input1 -= input2;
   ASSERT_TRUE(input1.get_input_vector().isApprox(d1));
 
@@ -114,8 +116,8 @@ TEST_F(ControlInputTest, Multiplication) {
   d1 << 2, 4, 6;
   d2 << -4, -5, -6;
 
-  ControlInput input1(i1);
-  ControlInput input2(i2);
+  ControlInput input1{i1};
+  ControlInput input2{i2};
 
   input1 *= 2.0;
   ASSERT_TRUE(input1.get_input_vector().isApprox(d1));
@@ -124,6 +126,20 @@ TEST_F(ControlInputTest, Multiplication) {
   ControlInput input4 = -1 * input2;
   ASSERT_TRUE(input3.get_input_vector().isApprox(d2));
   ASSERT_TRUE(input4.get_input_vector().isApprox(d2));
+}
+
+TEST_F(ControlInputTest, EmptyControlInputOperations) {
+  // Basic operations on empty velocities must result in empty velocities.
+  ControlInput input1, input2;
+
+  ControlInput input_add = input1 + input2;
+  ASSERT_TRUE(input_add.is_empty());
+
+  ControlInput input_sub = input1 - input2;
+  ASSERT_TRUE(input_sub.is_empty());
+
+  ControlInput input_mult = input1 * 7.0;
+  ASSERT_TRUE(input_mult.is_empty());
 }
 
 }  // namespace

--- a/src/morphac/constructs/test/control_input_test.cc
+++ b/src/morphac/constructs/test/control_input_test.cc
@@ -44,6 +44,16 @@ TEST_F(ControlInputTest, InvalidConstruction) {
   ASSERT_THROW(ControlInput(VectorXd::Random(0)), std::invalid_argument);
 }
 
+TEST_F(ControlInputTest, EmptyConstruction) {
+  ControlInput input;
+
+  // Accessors are invalid for empty velocity
+  ASSERT_THROW(input.get_input_vector(), std::logic_error);
+  ASSERT_THROW(input.get_input_at(0), std::logic_error);
+  ASSERT_THROW(input.set_input_vector(VectorXd::Random(0)), std::logic_error);
+  ASSERT_THROW(input.set_input_at(0, 0.0), std::logic_error);
+}
+
 TEST_F(ControlInputTest, InvalidGet) {
   ASSERT_THROW(input1_.get_input_at(-1), std::out_of_range);
   ASSERT_THROW(input1_.get_input_at(3), std::out_of_range);
@@ -93,7 +103,8 @@ TEST_F(ControlInputTest, Subtraction) {
   ASSERT_TRUE(input3.get_input_vector().isApprox(d2));
 
   ControlInput input4 = input2 - input1;
-  ASSERT_TRUE(input3.get_input_vector().isApprox(-1 * input4.get_input_vector()));
+  ASSERT_TRUE(
+      input3.get_input_vector().isApprox(-1 * input4.get_input_vector()));
 }
 
 TEST_F(ControlInputTest, Multiplication) {
@@ -114,8 +125,6 @@ TEST_F(ControlInputTest, Multiplication) {
   ASSERT_TRUE(input3.get_input_vector().isApprox(d2));
   ASSERT_TRUE(input4.get_input_vector().isApprox(d2));
 }
-
-
 
 }  // namespace
 

--- a/src/morphac/constructs/test/control_input_test.cc
+++ b/src/morphac/constructs/test/control_input_test.cc
@@ -52,7 +52,7 @@ TEST_F(ControlInputTest, SetInput) {
   ASSERT_TRUE(input3_.get_input_vector().isApprox(v));
 }
 
-TEST_F(ControlInputTest, ConstInputGet) {
+TEST_F(ControlInputTest, ConstInput) {
   const ControlInput input{3};
 
   // For a const ControlInput, the values can only be accessed but not set, as a

--- a/src/morphac/constructs/test/control_input_test.cc
+++ b/src/morphac/constructs/test/control_input_test.cc
@@ -29,14 +29,26 @@ TEST_F(ControlInputTest, Sizes) {
 
 TEST_F(ControlInputTest, CopyConstructor) {
   ASSERT_EQ(input3_.get_size(), input4_.get_size());
-  for (int i = 0; i < input3_.get_size(); ++i) {
-    ASSERT_EQ(input3_.get_input_at(i), input4_.get_input_at(i));
+  ASSERT_TRUE(input3_.get_input_vector().isApprox(input4_.get_input_vector()));
+}
+
+TEST_F(ControlInputTest, GetInput) {
+  ASSERT_TRUE(input1_.get_input_vector().isApprox(VectorXd::Zero(3)));
+
+  for (int i = 0; i < input2_.get_size(); ++i) {
+    ASSERT_EQ(input2_(i), 0);
   }
 }
 
-TEST_F(ControlInputTest, SetControlInput) {
-  input3_.set_input_at(1, 7.0);
-  ASSERT_EQ(input3_.get_input_at(1), 7.0);
+TEST_F(ControlInputTest, SetInput) {
+  input1_.set_input_vector(VectorXd::Ones(3));
+  ASSERT_TRUE(input1_.get_input_vector().isApprox(VectorXd::Ones(3)));
+
+  VectorXd v = VectorXd::Random(input3_.get_size());
+  for (int i = 0; i < input3_.get_size(); ++i) {
+    input3_(i) = v(i);
+  }
+  ASSERT_TRUE(input3_.get_input_vector().isApprox(v));
 }
 
 TEST_F(ControlInputTest, InvalidConstruction) {
@@ -51,14 +63,13 @@ TEST_F(ControlInputTest, EmptyConstruction) {
 
   // Accessors are invalid for empty ControlInput
   ASSERT_THROW(input.get_input_vector(), std::logic_error);
-  ASSERT_THROW(input.get_input_at(0), std::logic_error);
+  ASSERT_THROW(input(0), std::logic_error);
   ASSERT_THROW(input.set_input_vector(VectorXd::Random(0)), std::logic_error);
-  ASSERT_THROW(input.set_input_at(0, 0.0), std::logic_error);
 }
 
 TEST_F(ControlInputTest, InvalidGet) {
-  ASSERT_THROW(input1_.get_input_at(-1), std::out_of_range);
-  ASSERT_THROW(input1_.get_input_at(3), std::out_of_range);
+  ASSERT_THROW(input1_(-1), std::out_of_range);
+  ASSERT_THROW(input1_(3), std::out_of_range);
 }
 
 TEST_F(ControlInputTest, InvalidSet) {
@@ -66,8 +77,6 @@ TEST_F(ControlInputTest, InvalidSet) {
                std::invalid_argument);
   ASSERT_THROW(input1_.set_input_vector(VectorXd::Random(2)),
                std::invalid_argument);
-  ASSERT_THROW(input1_.set_input_at(-1, 1), std::out_of_range);
-  ASSERT_THROW(input1_.set_input_at(7, 1), std::out_of_range);
 }
 
 TEST_F(ControlInputTest, Addition) {

--- a/src/morphac/constructs/test/control_input_test.cc
+++ b/src/morphac/constructs/test/control_input_test.cc
@@ -68,7 +68,7 @@ TEST_F(ControlInputTest, EmptyConstruction) {
   ControlInput input;
 
   // Assert emptiness
-  ASSERT_TRUE(input.is_empty());
+  ASSERT_TRUE(input.IsEmpty());
 
   // Accessors are invalid for empty ControlInput
   ASSERT_THROW(input.get_input_vector(), std::logic_error);
@@ -151,13 +151,13 @@ TEST_F(ControlInputTest, EmptyControlInputOperations) {
   ControlInput input1, input2;
 
   ControlInput input_add = input1 + input2;
-  ASSERT_TRUE(input_add.is_empty());
+  ASSERT_TRUE(input_add.IsEmpty());
 
   ControlInput input_sub = input1 - input2;
-  ASSERT_TRUE(input_sub.is_empty());
+  ASSERT_TRUE(input_sub.IsEmpty());
 
   ControlInput input_mult = input1 * 7.0;
-  ASSERT_TRUE(input_mult.is_empty());
+  ASSERT_TRUE(input_mult.IsEmpty());
 }
 
 TEST_F(ControlInputTest, CreateLike) {

--- a/src/morphac/constructs/test/control_input_test.cc
+++ b/src/morphac/constructs/test/control_input_test.cc
@@ -25,6 +25,7 @@ class ControlInputTest : public ::testing::Test {
 TEST_F(ControlInputTest, Sizes) {
   ASSERT_EQ(input1_.get_size(), input2_.get_size());
   ASSERT_EQ(input1_.get_input_vector(), input2_.get_input_vector());
+  ASSERT_EQ(input3_.get_size(), 6);
 }
 
 TEST_F(ControlInputTest, CopyConstructor) {

--- a/src/morphac/constructs/test/pose_test.cc
+++ b/src/morphac/constructs/test/pose_test.cc
@@ -52,6 +52,14 @@ TEST_F(PoseTest, SetPose) {
   ASSERT_TRUE(pose3_.get_pose_vector().isApprox(v));
 }
 
+TEST_F(PoseTest, ConstPoseGet) {
+  const Pose pose{3};
+
+  // For a const Pose, the values can only be accessed but not set, as a
+  // reference (lvalue) is not returned for this overload of the operator.
+  ASSERT_EQ(pose(0), 0);
+}
+
 TEST_F(PoseTest, InvalidConstruction) {
   ASSERT_THROW(Pose{-1}, std::invalid_argument);
 }

--- a/src/morphac/constructs/test/pose_test.cc
+++ b/src/morphac/constructs/test/pose_test.cc
@@ -52,7 +52,7 @@ TEST_F(PoseTest, SetPose) {
   ASSERT_TRUE(pose3_.get_pose_vector().isApprox(v));
 }
 
-TEST_F(PoseTest, ConstPoseGet) {
+TEST_F(PoseTest, ConstPose) {
   const Pose pose{3};
 
   // For a const Pose, the values can only be accessed but not set, as a

--- a/src/morphac/constructs/test/pose_test.cc
+++ b/src/morphac/constructs/test/pose_test.cc
@@ -68,7 +68,7 @@ TEST_F(PoseTest, EmptyConstruction) {
   Pose pose;
 
   // Assert emptiness.
-  ASSERT_TRUE(pose.is_empty());
+  ASSERT_TRUE(pose.IsEmpty());
 
   // Accessors are invalid for empty Pose
   ASSERT_THROW(pose.get_pose_vector(), std::logic_error);
@@ -150,13 +150,13 @@ TEST_F(PoseTest, EmptyPoseOperations) {
   Pose pose1, pose2;
 
   Pose pose_add = pose1 + pose2;
-  ASSERT_TRUE(pose_add.is_empty());
+  ASSERT_TRUE(pose_add.IsEmpty());
 
   Pose pose_sub = pose1 - pose2;
-  ASSERT_TRUE(pose_sub.is_empty());
+  ASSERT_TRUE(pose_sub.IsEmpty());
 
   Pose pose_mult = pose1 * 7.0;
-  ASSERT_TRUE(pose_mult.is_empty());
+  ASSERT_TRUE(pose_mult.IsEmpty());
 }
 
 TEST_F(PoseTest, CreateLike) {

--- a/src/morphac/constructs/test/pose_test.cc
+++ b/src/morphac/constructs/test/pose_test.cc
@@ -25,6 +25,7 @@ class PoseTest : public ::testing::Test {
 TEST_F(PoseTest, Sizes) {
   ASSERT_EQ(pose1_.get_size(), pose2_.get_size());
   ASSERT_EQ(pose1_.get_pose_vector(), pose2_.get_pose_vector());
+  ASSERT_EQ(pose3_.get_size(), 6);
 }
 
 TEST_F(PoseTest, CopyConstructor) {

--- a/src/morphac/constructs/test/pose_test.cc
+++ b/src/morphac/constructs/test/pose_test.cc
@@ -19,7 +19,7 @@ class PoseTest : public ::testing::Test {
   Pose pose2_{Pose(VectorXd::Zero(3))};
   VectorXd rand_pose_ = VectorXd::Random(6);
   Pose pose3_{Pose(rand_pose_)};
-  Pose pose4_ = pose3_;
+  Pose pose4_{pose3_};
 };
 
 TEST_F(PoseTest, Sizes) {
@@ -29,14 +29,26 @@ TEST_F(PoseTest, Sizes) {
 
 TEST_F(PoseTest, CopyConstructor) {
   ASSERT_EQ(pose3_.get_size(), pose4_.get_size());
-  for (int i = 0; i < pose3_.get_size(); ++i) {
-    ASSERT_EQ(pose3_.get_pose_at(i), pose4_.get_pose_at(i));
+  ASSERT_TRUE(pose3_.get_pose_vector().isApprox(pose4_.get_pose_vector()));
+}
+
+TEST_F(PoseTest, GetPose) {
+  ASSERT_TRUE(pose1_.get_pose_vector().isApprox(VectorXd::Zero(3)));
+
+  for (int i = 0; i < pose2_.get_size(); ++i) {
+    ASSERT_EQ(pose2_(i), 0);
   }
 }
 
 TEST_F(PoseTest, SetPose) {
-  pose3_.set_pose_at(1, 7.0);
-  ASSERT_EQ(pose3_.get_pose_at(1), 7.0);
+  pose1_.set_pose_vector(VectorXd::Ones(3));
+  ASSERT_TRUE(pose1_.get_pose_vector().isApprox(VectorXd::Ones(3)));
+
+  VectorXd v = VectorXd::Random(pose3_.get_size());
+  for (int i = 0; i < pose3_.get_size(); ++i) {
+    pose3_(i) = v(i);
+  }
+  ASSERT_TRUE(pose3_.get_pose_vector().isApprox(v));
 }
 
 TEST_F(PoseTest, InvalidConstruction) {
@@ -51,14 +63,13 @@ TEST_F(PoseTest, EmptyConstruction) {
 
   // Accessors are invalid for empty Pose
   ASSERT_THROW(pose.get_pose_vector(), std::logic_error);
-  ASSERT_THROW(pose.get_pose_at(0), std::logic_error);
+  ASSERT_THROW(pose(0), std::logic_error);
   ASSERT_THROW(pose.set_pose_vector(VectorXd::Random(0)), std::logic_error);
-  ASSERT_THROW(pose.set_pose_at(0, 0.0), std::logic_error);
 }
 
 TEST_F(PoseTest, InvalidGet) {
-  ASSERT_THROW(pose1_.get_pose_at(-1), std::out_of_range);
-  ASSERT_THROW(pose1_.get_pose_at(3), std::out_of_range);
+  ASSERT_THROW(pose1_(-1), std::out_of_range);
+  ASSERT_THROW(pose1_(3), std::out_of_range);
 }
 
 TEST_F(PoseTest, InvalidSet) {
@@ -66,8 +77,6 @@ TEST_F(PoseTest, InvalidSet) {
                std::invalid_argument);
   ASSERT_THROW(pose1_.set_pose_vector(VectorXd::Random(2)),
                std::invalid_argument);
-  ASSERT_THROW(pose1_.set_pose_at(-1, 1), std::out_of_range);
-  ASSERT_THROW(pose1_.set_pose_at(7, 1), std::out_of_range);
 }
 
 TEST_F(PoseTest, Addition) {
@@ -137,7 +146,7 @@ TEST_F(PoseTest, EmptyPoseOperations) {
   Pose pose_sub = pose1 - pose2;
   ASSERT_TRUE(pose_sub.is_empty());
 
-  Pose pose_mult =  pose1 * 7.0;
+  Pose pose_mult = pose1 * 7.0;
   ASSERT_TRUE(pose_mult.is_empty());
 }
 

--- a/src/morphac/constructs/test/pose_test.cc
+++ b/src/morphac/constructs/test/pose_test.cc
@@ -159,6 +159,17 @@ TEST_F(PoseTest, EmptyPoseOperations) {
   ASSERT_TRUE(pose_mult.is_empty());
 }
 
+TEST_F(PoseTest, CreateLike) {
+  Pose pose1 = Pose::CreateLike(pose1_);
+  Pose pose2 = Pose::CreateLike(pose3_);
+
+  ASSERT_EQ(pose1.get_size(), 3);
+  ASSERT_TRUE(pose1.get_pose_vector().isApprox(VectorXd::Zero(3)));
+
+  ASSERT_EQ(pose2.get_size(), 6);
+  ASSERT_TRUE(pose2.get_pose_vector().isApprox(VectorXd::Zero(6)));
+}
+
 }  // namespace
 
 int main(int argc, char **argv) {

--- a/src/morphac/constructs/test/pose_test.cc
+++ b/src/morphac/constructs/test/pose_test.cc
@@ -44,6 +44,14 @@ TEST_F(PoseTest, InvalidConstruction) {
   ASSERT_THROW(Pose(VectorXd::Random(0)), std::invalid_argument);
 }
 
+TEST_F(PoseTest, EmptyConstruction) {
+  Pose pose;
+  ASSERT_THROW(pose.get_pose_vector(), std::logic_error);
+  ASSERT_THROW(pose.get_pose_at(0), std::logic_error);
+  ASSERT_THROW(pose.set_pose_vector(VectorXd::Random(0)), std::logic_error);
+  ASSERT_THROW(pose.set_pose_at(0, 0.0), std::logic_error);
+}
+
 TEST_F(PoseTest, InvalidGet) {
   ASSERT_THROW(pose1_.get_pose_at(-1), std::out_of_range);
   ASSERT_THROW(pose1_.get_pose_at(3), std::out_of_range);

--- a/src/morphac/constructs/test/pose_test.cc
+++ b/src/morphac/constructs/test/pose_test.cc
@@ -40,12 +40,16 @@ TEST_F(PoseTest, SetPose) {
 }
 
 TEST_F(PoseTest, InvalidConstruction) {
-  ASSERT_THROW(Pose(0), std::invalid_argument);
-  ASSERT_THROW(Pose(VectorXd::Random(0)), std::invalid_argument);
+  ASSERT_THROW(Pose{-1}, std::invalid_argument);
 }
 
 TEST_F(PoseTest, EmptyConstruction) {
   Pose pose;
+
+  // Assert emptiness.
+  ASSERT_TRUE(pose.is_empty());
+
+  // Accessors are invalid for empty Pose
   ASSERT_THROW(pose.get_pose_vector(), std::logic_error);
   ASSERT_THROW(pose.get_pose_at(0), std::logic_error);
   ASSERT_THROW(pose.set_pose_vector(VectorXd::Random(0)), std::logic_error);
@@ -73,8 +77,8 @@ TEST_F(PoseTest, Addition) {
   d1 << 5, 7, 9;
   d2 << 9, 12, 15;
 
-  Pose pose1(p1);
-  Pose pose2(p2);
+  Pose pose1{p1};
+  Pose pose2{p2};
   pose1 += pose2;
   ASSERT_TRUE(pose1.get_pose_vector().isApprox(d1));
 
@@ -92,8 +96,8 @@ TEST_F(PoseTest, Subtraction) {
   d1 << -3, -3, -3;
   d2 << -7, -8, -9;
 
-  Pose pose1(p1);
-  Pose pose2(p2);
+  Pose pose1{p1};
+  Pose pose2{p2};
   pose1 -= pose2;
   ASSERT_TRUE(pose1.get_pose_vector().isApprox(d1));
 
@@ -111,8 +115,8 @@ TEST_F(PoseTest, Multiplication) {
   d1 << 2, 4, 6;
   d2 << -4, -5, -6;
 
-  Pose pose1(p1);
-  Pose pose2(p2);
+  Pose pose1{p1};
+  Pose pose2{p2};
 
   pose1 *= 2.0;
   ASSERT_TRUE(pose1.get_pose_vector().isApprox(d1));
@@ -121,6 +125,20 @@ TEST_F(PoseTest, Multiplication) {
   Pose pose4 = -1 * pose2;
   ASSERT_TRUE(pose3.get_pose_vector().isApprox(d2));
   ASSERT_TRUE(pose4.get_pose_vector().isApprox(d2));
+}
+
+TEST_F(PoseTest, EmptyPoseOperations) {
+  // Basic operations on empty velocities must result in empty velocities.
+  Pose pose1, pose2;
+
+  Pose pose_add = pose1 + pose2;
+  ASSERT_TRUE(pose_add.is_empty());
+
+  Pose pose_sub = pose1 - pose2;
+  ASSERT_TRUE(pose_sub.is_empty());
+
+  Pose pose_mult =  pose1 * 7.0;
+  ASSERT_TRUE(pose_mult.is_empty());
 }
 
 }  // namespace

--- a/src/morphac/constructs/test/state_test.cc
+++ b/src/morphac/constructs/test/state_test.cc
@@ -28,9 +28,9 @@ class StateTest : public ::testing::Test {
   }
 
   void SetUp() override {
-    state1_ = new State(3, 2);
-    state2_ = new State(pose_vector1_, velocity_vector1_);
-    state3_ = new State(Pose(pose_vector1_), Velocity(velocity_vector1_));
+    state1_ = new State{3, 2};
+    state2_ = new State{pose_vector1_, velocity_vector1_};
+    state3_ = new State{Pose(pose_vector1_), Velocity(velocity_vector1_)};
   }
 
   VectorXd pose_vector1_, velocity_vector1_;
@@ -171,8 +171,8 @@ TEST_F(StateTest, Addition) {
   s1 << p1, v1;
   s2 << p2, v2;
 
-  State state1(p1, v1);
-  State state2(p2, v2);
+  State state1{p1, v1};
+  State state2{p2, v2};
 
   state1 += state2;
   ASSERT_TRUE(state1.get_state_vector().isApprox(d1));
@@ -197,8 +197,8 @@ TEST_F(StateTest, Subtraction) {
   s1 << p1, v1;
   s2 << p2, v2;
 
-  State state1(p1, v1);
-  State state2(p2, v2);
+  State state1{p1, v1};
+  State state2{p2, v2};
 
   state1 -= state2;
   ASSERT_TRUE(state1.get_state_vector().isApprox(d1));
@@ -222,8 +222,8 @@ TEST_F(StateTest, Multiplication) {
   d1 << 2, 4, 6, -2, 0;
   d2 << -3, -2, -1, 2, -4;
 
-  State state1(p1, v1);
-  State state2(p2, v2);
+  State state1{p1, v1};
+  State state2{p2, v2};
 
   state1 *= 2.0;
   ASSERT_TRUE(state1.get_state_vector().isApprox(d1));
@@ -236,9 +236,102 @@ TEST_F(StateTest, Multiplication) {
 
 TEST_F(StateTest, PartialConstruction) {
   // Constructing states without the velocity component.
-  State state1(3);
-  State state2(VectorXd::Random(4));
-  //State state3(Pose(5));
+  State state1{3, 0};
+  State state2{VectorXd::Zero(4), VectorXd::Zero(0)};
+  State state3{Pose(5), Velocity()};
+
+  // Constructing states without the pose component.
+  State state4{0, 3};
+  State state5{VectorXd::Zero(0), VectorXd::Zero(4)};
+  State state6{Pose(), Velocity(5)};
+
+  // Both empty (empty state)
+  State state7{0, 0};
+
+  // Test emptiness.
+  ASSERT_TRUE(!state1.is_empty());
+  ASSERT_TRUE(state1.is_velocity_empty());
+  ASSERT_TRUE(!state2.is_empty());
+  ASSERT_TRUE(state2.is_velocity_empty());
+  ASSERT_TRUE(!state3.is_empty());
+  ASSERT_TRUE(state3.is_velocity_empty());
+
+  ASSERT_TRUE(!state4.is_empty());
+  ASSERT_TRUE(state4.is_pose_empty());
+  ASSERT_TRUE(!state5.is_empty());
+  ASSERT_TRUE(state5.is_pose_empty());
+  ASSERT_TRUE(!state6.is_empty());
+  ASSERT_TRUE(state6.is_pose_empty());
+
+  ASSERT_TRUE(state7.is_empty());
+
+  // Accessors to the empty component must throw errors.
+  ASSERT_THROW(state1.get_velocity_vector(), std::logic_error);
+  ASSERT_THROW(state1.get_velocity_at(0), std::logic_error);
+  ASSERT_THROW(state1.set_velocity_vector(VectorXd::Zero(0)), std::logic_error);
+  ASSERT_THROW(state1.set_velocity_at(0, 0.0), std::logic_error);
+  ASSERT_THROW(state2.get_velocity_vector(), std::logic_error);
+  ASSERT_THROW(state2.get_velocity_at(0), std::logic_error);
+  ASSERT_THROW(state2.set_velocity_vector(VectorXd::Zero(0)), std::logic_error);
+  ASSERT_THROW(state2.set_velocity_at(0, 0.0), std::logic_error);
+  ASSERT_THROW(state3.get_velocity_vector(), std::logic_error);
+  ASSERT_THROW(state3.get_velocity_at(0), std::logic_error);
+  ASSERT_THROW(state3.set_velocity_vector(VectorXd::Zero(0)), std::logic_error);
+  ASSERT_THROW(state3.set_velocity_at(0, 0.0), std::logic_error);
+  ASSERT_THROW(state7.get_velocity_vector(), std::logic_error);
+  ASSERT_THROW(state7.get_velocity_at(0), std::logic_error);
+  ASSERT_THROW(state7.set_velocity_vector(VectorXd::Zero(0)), std::logic_error);
+  ASSERT_THROW(state7.set_velocity_at(0, 0.0), std::logic_error);
+
+  ASSERT_THROW(state4.get_pose_vector(), std::logic_error);
+  ASSERT_THROW(state4.get_pose_at(0), std::logic_error);
+  ASSERT_THROW(state4.set_pose_vector(VectorXd::Zero(0)), std::logic_error);
+  ASSERT_THROW(state4.set_pose_at(0, 0.0), std::logic_error);
+  ASSERT_THROW(state5.get_pose_vector(), std::logic_error);
+  ASSERT_THROW(state5.get_pose_at(0), std::logic_error);
+  ASSERT_THROW(state5.set_pose_vector(VectorXd::Zero(0)), std::logic_error);
+  ASSERT_THROW(state5.set_pose_at(0, 0.0), std::logic_error);
+  ASSERT_THROW(state6.get_pose_vector(), std::logic_error);
+  ASSERT_THROW(state6.get_pose_at(0), std::logic_error);
+  ASSERT_THROW(state6.set_pose_vector(VectorXd::Zero(0)), std::logic_error);
+  ASSERT_THROW(state6.set_pose_at(0, 0.0), std::logic_error);
+  ASSERT_THROW(state7.get_pose_vector(), std::logic_error);
+  ASSERT_THROW(state7.get_pose_at(0), std::logic_error);
+  ASSERT_THROW(state7.set_pose_vector(VectorXd::Zero(0)), std::logic_error);
+  ASSERT_THROW(state7.set_pose_at(0, 0.0), std::logic_error);
+
+  // Operations should work as usual taking only the pose/velocity into account.
+  State state_add_pose = state1 + State{VectorXd::Ones(3), VectorXd::Zero(0)};
+  State state_add_vel = state4 + State{VectorXd::Zero(0), VectorXd::Ones(3)};
+  ASSERT_TRUE(!state_add_pose.is_empty());
+  ASSERT_TRUE(state_add_pose.is_velocity_empty());
+  ASSERT_TRUE(!state_add_vel.is_empty());
+  ASSERT_TRUE(state_add_vel.is_pose_empty());
+  ASSERT_TRUE(state_add_pose.get_pose_vector().isApprox(VectorXd::Ones(3)));
+  ASSERT_TRUE(state_add_vel.get_velocity_vector().isApprox(VectorXd::Ones(3)));
+
+  State state_sub_pose = state2 - State{VectorXd::Ones(4), VectorXd::Zero(0)};
+  State state_sub_vel = state5 - State{VectorXd::Zero(0), VectorXd::Ones(4)};
+  ASSERT_TRUE(!state_sub_pose.is_empty());
+  ASSERT_TRUE(state_sub_pose.is_velocity_empty());
+  ASSERT_TRUE(!state_sub_vel.is_empty());
+  ASSERT_TRUE(state_sub_vel.is_pose_empty());
+  ASSERT_TRUE(
+      state_sub_pose.get_pose_vector().isApprox(-1 * VectorXd::Ones(4)));
+  ASSERT_TRUE(
+      state_sub_vel.get_velocity_vector().isApprox(-1 * VectorXd::Ones(4)));
+
+  State state_mult_pose = state3 * 5.;
+  State state_mult_vel = state6 * 5.;
+  ASSERT_TRUE(!state_mult_pose.is_empty());
+  ASSERT_TRUE(state_mult_pose.is_velocity_empty());
+  ASSERT_TRUE(!state_mult_vel.is_empty());
+  ASSERT_TRUE(state_mult_vel.is_pose_empty());
+  ASSERT_TRUE(state_mult_pose.get_pose_vector().isApprox(VectorXd::Zero(5)));
+  ASSERT_TRUE(state_mult_vel.get_velocity_vector().isApprox(VectorXd::Zero(5)));
+
+  State state_empty = state7 + State{0, 0};
+  ASSERT_TRUE(state_empty.is_empty());
 }
 
 }  // namespace

--- a/src/morphac/constructs/test/state_test.cc
+++ b/src/morphac/constructs/test/state_test.cc
@@ -119,6 +119,14 @@ TEST_F(StateTest, SetAt) {
   ASSERT_TRUE(state2_->get_state_vector().isApprox(v));
 }
 
+TEST_F(StateTest, ConstStateGet) {
+  const State state{3, 3};
+
+  // For a const State, the values can only be accessed but not set, as a
+  // reference (lvalue) is not returned for this overload of the operator.
+  ASSERT_EQ(state(0), 0);
+}
+
 TEST_F(StateTest, InvalidGet) {
   ASSERT_THROW(state2_->get_pose()(-1), std::out_of_range);
   ASSERT_THROW(state2_->get_pose()(4), std::out_of_range);

--- a/src/morphac/constructs/test/state_test.cc
+++ b/src/morphac/constructs/test/state_test.cc
@@ -344,6 +344,21 @@ TEST_F(StateTest, PartialConstruction) {
   ASSERT_TRUE(state_empty.is_empty());
 }
 
+TEST_F(StateTest, CreateLike) {
+  State state1 = State::CreateLike(*state1_);
+  State state2 = State::CreateLike(*state2_);
+
+  ASSERT_EQ(state1.get_size_pose(), 3);
+  ASSERT_EQ(state1.get_size_velocity(), 2);
+  ASSERT_TRUE(state1.get_pose_vector().isApprox(VectorXd::Zero(3)));
+  ASSERT_TRUE(state1.get_velocity_vector().isApprox(VectorXd::Zero(2)));
+
+  ASSERT_EQ(state2.get_size_pose(), 4);
+  ASSERT_EQ(state2.get_size_velocity(), 2);
+  ASSERT_TRUE(state2.get_pose_vector().isApprox(VectorXd::Zero(4)));
+  ASSERT_TRUE(state2.get_velocity_vector().isApprox(VectorXd::Zero(2)));
+}
+
 }  // namespace
 
 int main(int argc, char **argv) {

--- a/src/morphac/constructs/test/state_test.cc
+++ b/src/morphac/constructs/test/state_test.cc
@@ -173,7 +173,7 @@ TEST_F(StateTest, InvalidSet) {
 TEST_F(StateTest, EmptyConstruction) {
   State state;
 
-  ASSERT_TRUE(state.is_empty());
+  ASSERT_TRUE(state.IsEmpty());
 }
 
 TEST_F(StateTest, Addition) {
@@ -267,65 +267,97 @@ TEST_F(StateTest, PartialConstruction) {
   State state7{0, 0};
 
   // Test emptiness.
-  ASSERT_TRUE(!state1.is_empty());
-  ASSERT_TRUE(state1.is_velocity_empty());
-  ASSERT_TRUE(!state2.is_empty());
-  ASSERT_TRUE(state2.is_velocity_empty());
-  ASSERT_TRUE(!state3.is_empty());
-  ASSERT_TRUE(state3.is_velocity_empty());
+  ASSERT_TRUE(!state1.IsEmpty());
+  ASSERT_TRUE(state1.IsVelocityEmpty());
+  ASSERT_TRUE(!state2.IsEmpty());
+  ASSERT_TRUE(state2.IsVelocityEmpty());
+  ASSERT_TRUE(!state3.IsEmpty());
+  ASSERT_TRUE(state3.IsVelocityEmpty());
 
-  ASSERT_TRUE(!state4.is_empty());
-  ASSERT_TRUE(state4.is_pose_empty());
-  ASSERT_TRUE(!state5.is_empty());
-  ASSERT_TRUE(state5.is_pose_empty());
-  ASSERT_TRUE(!state6.is_empty());
-  ASSERT_TRUE(state6.is_pose_empty());
+  ASSERT_TRUE(!state4.IsEmpty());
+  ASSERT_TRUE(state4.IsPoseEmpty());
+  ASSERT_TRUE(!state5.IsEmpty());
+  ASSERT_TRUE(state5.IsPoseEmpty());
+  ASSERT_TRUE(!state6.IsEmpty());
+  ASSERT_TRUE(state6.IsPoseEmpty());
 
-  ASSERT_TRUE(state7.is_empty());
+  ASSERT_TRUE(state7.IsEmpty());
 
-  // Accessors to the empty component must throw errors.
+  // Accessors to the empty component (velocity) must throw errors.
   ASSERT_THROW(state1.get_velocity_vector(), std::logic_error);
   ASSERT_THROW(state1.get_velocity()(0), std::logic_error);
   ASSERT_THROW(state1.set_velocity_vector(VectorXd::Zero(0)), std::logic_error);
+  // The state vectors must be accessible.
+  ASSERT_TRUE(state1.get_state_vector().isApprox(VectorXd::Zero(3)));
+
   ASSERT_THROW(state2.get_velocity_vector(), std::logic_error);
   ASSERT_THROW(state2.get_velocity()(0), std::logic_error);
   ASSERT_THROW(state2.set_velocity_vector(VectorXd::Zero(0)), std::logic_error);
+  ASSERT_TRUE(state2.get_state_vector().isApprox(VectorXd::Zero(4)));
+
   ASSERT_THROW(state3.get_velocity_vector(), std::logic_error);
   ASSERT_THROW(state3.get_velocity()(0), std::logic_error);
   ASSERT_THROW(state3.set_velocity_vector(VectorXd::Zero(0)), std::logic_error);
+  ASSERT_TRUE(state3.get_state_vector().isApprox(VectorXd::Zero(5)));
+
   ASSERT_THROW(state7.get_velocity_vector(), std::logic_error);
   ASSERT_THROW(state7.get_velocity()(0), std::logic_error);
   ASSERT_THROW(state7.set_velocity_vector(VectorXd::Zero(0)), std::logic_error);
 
+  // Setting the state vector should work for a partial state.
+  VectorXd v = VectorXd::Random(3);
+  state1.set_state_vector(v);
+  ASSERT_TRUE(state1.get_pose_vector().isApprox(v));
+  ASSERT_TRUE(state1.get_state_vector().isApprox(v));
+  // Resetting the value.
+  state1.set_state_vector(VectorXd::Zero(3));
+
+  // Accessors to the empty component (pose) must throw errors.
   ASSERT_THROW(state4.get_pose_vector(), std::logic_error);
   ASSERT_THROW(state4.get_pose()(0), std::logic_error);
   ASSERT_THROW(state4.set_pose_vector(VectorXd::Zero(0)), std::logic_error);
+  ASSERT_TRUE(state4.get_state_vector().isApprox(VectorXd::Zero(3)));
+
   ASSERT_THROW(state5.get_pose_vector(), std::logic_error);
   ASSERT_THROW(state5.get_pose()(0), std::logic_error);
   ASSERT_THROW(state5.set_pose_vector(VectorXd::Zero(0)), std::logic_error);
+  ASSERT_TRUE(state5.get_state_vector().isApprox(VectorXd::Zero(4)));
+
   ASSERT_THROW(state6.get_pose_vector(), std::logic_error);
   ASSERT_THROW(state6.get_pose()(0), std::logic_error);
   ASSERT_THROW(state6.set_pose_vector(VectorXd::Zero(0)), std::logic_error);
+  ASSERT_TRUE(state6.get_state_vector().isApprox(VectorXd::Zero(5)));
+
   ASSERT_THROW(state7.get_pose_vector(), std::logic_error);
   ASSERT_THROW(state7.get_pose()(0), std::logic_error);
   ASSERT_THROW(state7.set_pose_vector(VectorXd::Zero(0)), std::logic_error);
 
+  // Setting the state vector should work for a partial state.
+  v = VectorXd::Random(3);
+  state4.set_state_vector(v);
+  ASSERT_TRUE(state4.get_velocity_vector().isApprox(v));
+  ASSERT_TRUE(state4.get_state_vector().isApprox(v));
+  // Resetting the value.
+  state4.set_state_vector(VectorXd::Zero(3));
+
+  ASSERT_THROW(state7.get_state_vector(), std::logic_error);
+
   // Operations should work as usual taking only the pose/velocity into account.
   State state_add_pose = state1 + State{VectorXd::Ones(3), VectorXd::Zero(0)};
   State state_add_vel = state4 + State{VectorXd::Zero(0), VectorXd::Ones(3)};
-  ASSERT_TRUE(!state_add_pose.is_empty());
-  ASSERT_TRUE(state_add_pose.is_velocity_empty());
-  ASSERT_TRUE(!state_add_vel.is_empty());
-  ASSERT_TRUE(state_add_vel.is_pose_empty());
+  ASSERT_TRUE(!state_add_pose.IsEmpty());
+  ASSERT_TRUE(state_add_pose.IsVelocityEmpty());
+  ASSERT_TRUE(!state_add_vel.IsEmpty());
+  ASSERT_TRUE(state_add_vel.IsPoseEmpty());
   ASSERT_TRUE(state_add_pose.get_pose_vector().isApprox(VectorXd::Ones(3)));
   ASSERT_TRUE(state_add_vel.get_velocity_vector().isApprox(VectorXd::Ones(3)));
 
   State state_sub_pose = state2 - State{VectorXd::Ones(4), VectorXd::Zero(0)};
   State state_sub_vel = state5 - State{VectorXd::Zero(0), VectorXd::Ones(4)};
-  ASSERT_TRUE(!state_sub_pose.is_empty());
-  ASSERT_TRUE(state_sub_pose.is_velocity_empty());
-  ASSERT_TRUE(!state_sub_vel.is_empty());
-  ASSERT_TRUE(state_sub_vel.is_pose_empty());
+  ASSERT_TRUE(!state_sub_pose.IsEmpty());
+  ASSERT_TRUE(state_sub_pose.IsVelocityEmpty());
+  ASSERT_TRUE(!state_sub_vel.IsEmpty());
+  ASSERT_TRUE(state_sub_vel.IsPoseEmpty());
   ASSERT_TRUE(
       state_sub_pose.get_pose_vector().isApprox(-1 * VectorXd::Ones(4)));
   ASSERT_TRUE(
@@ -333,15 +365,15 @@ TEST_F(StateTest, PartialConstruction) {
 
   State state_mult_pose = state3 * 5.;
   State state_mult_vel = state6 * 5.;
-  ASSERT_TRUE(!state_mult_pose.is_empty());
-  ASSERT_TRUE(state_mult_pose.is_velocity_empty());
-  ASSERT_TRUE(!state_mult_vel.is_empty());
-  ASSERT_TRUE(state_mult_vel.is_pose_empty());
+  ASSERT_TRUE(!state_mult_pose.IsEmpty());
+  ASSERT_TRUE(state_mult_pose.IsVelocityEmpty());
+  ASSERT_TRUE(!state_mult_vel.IsEmpty());
+  ASSERT_TRUE(state_mult_vel.IsPoseEmpty());
   ASSERT_TRUE(state_mult_pose.get_pose_vector().isApprox(VectorXd::Zero(5)));
   ASSERT_TRUE(state_mult_vel.get_velocity_vector().isApprox(VectorXd::Zero(5)));
 
   State state_empty = state7 + State{};
-  ASSERT_TRUE(state_empty.is_empty());
+  ASSERT_TRUE(state_empty.IsEmpty());
 }
 
 TEST_F(StateTest, CreateLike) {

--- a/src/morphac/constructs/test/state_test.cc
+++ b/src/morphac/constructs/test/state_test.cc
@@ -119,12 +119,29 @@ TEST_F(StateTest, SetAt) {
   ASSERT_TRUE(state2_->get_state_vector().isApprox(v));
 }
 
-TEST_F(StateTest, ConstStateGet) {
+TEST_F(StateTest, ConstState) {
   const State state{3, 3};
+
+  // We should be able to obtain const Pose and const Velocity objects from this
+  // const state (these are read-only).
+  ASSERT_TRUE(state.get_pose().get_pose_vector().isApprox(VectorXd::Zero(3)));
+  ASSERT_TRUE(
+      state.get_velocity().get_velocity_vector().isApprox(VectorXd::Zero(3)));
+
+  // After const casting to a non-const, we should be able to modify the Pose
+  // and Velocity.
+  const_cast<State &>(state).get_pose().set_pose_vector(VectorXd::Ones(3));
+  const_cast<State &>(state).get_velocity().set_velocity_vector(
+      VectorXd::Ones(3));
+  ASSERT_TRUE(state.get_pose().get_pose_vector().isApprox(VectorXd::Ones(3)));
+  ASSERT_TRUE(
+      state.get_velocity().get_velocity_vector().isApprox(VectorXd::Ones(3)));
 
   // For a const State, the values can only be accessed but not set, as a
   // reference (lvalue) is not returned for this overload of the operator.
-  ASSERT_EQ(state(0), 0);
+  for (int i = 0; i < state.get_size(); ++i) {
+    ASSERT_EQ(state(i), 1);
+  }
 }
 
 TEST_F(StateTest, InvalidGet) {

--- a/src/morphac/constructs/test/state_test.cc
+++ b/src/morphac/constructs/test/state_test.cc
@@ -234,6 +234,13 @@ TEST_F(StateTest, Multiplication) {
   ASSERT_TRUE(state4.get_state_vector().isApprox(d2));
 }
 
+TEST_F(StateTest, PartialConstruction) {
+  // Constructing states without the velocity component.
+  State state1(3);
+  State state2(VectorXd::Random(4));
+  //State state3(Pose(5));
+}
+
 }  // namespace
 
 int main(int argc, char **argv) {

--- a/src/morphac/constructs/test/state_test.cc
+++ b/src/morphac/constructs/test/state_test.cc
@@ -170,6 +170,12 @@ TEST_F(StateTest, InvalidSet) {
                std::invalid_argument);
 }
 
+TEST_F(StateTest, EmptyConstruction) {
+  State state;
+
+  ASSERT_TRUE(state.is_empty());
+}
+
 TEST_F(StateTest, Addition) {
   VectorXd p1(3), p2(3), v1(2), v2(2);
   VectorXd d1(5), d2(5);
@@ -334,7 +340,7 @@ TEST_F(StateTest, PartialConstruction) {
   ASSERT_TRUE(state_mult_pose.get_pose_vector().isApprox(VectorXd::Zero(5)));
   ASSERT_TRUE(state_mult_vel.get_velocity_vector().isApprox(VectorXd::Zero(5)));
 
-  State state_empty = state7 + State{0, 0};
+  State state_empty = state7 + State{};
   ASSERT_TRUE(state_empty.is_empty());
 }
 

--- a/src/morphac/constructs/test/velocity_test.cc
+++ b/src/morphac/constructs/test/velocity_test.cc
@@ -41,7 +41,17 @@ TEST_F(VelocityTest, SetVelocity) {
 
 TEST_F(VelocityTest, InvalidConstruction) {
   ASSERT_THROW(Velocity(0), std::invalid_argument);
-  ASSERT_THROW(Velocity(VectorXd::Random(0)), std::invalid_argument);
+  ASSERT_THROW(Velocity(-1), std::invalid_argument);
+}
+
+TEST_F(VelocityTest, EmptyConstruction) {
+  Velocity velocity;
+
+  // Accessors are invalid for empty velocity
+  ASSERT_THROW(velocity.get_velocity_vector(), std::logic_error);
+  ASSERT_THROW(velocity.get_velocity_at(0), std::logic_error);
+  ASSERT_THROW(velocity.set_velocity_vector(VectorXd::Random(0)), std::logic_error);
+  ASSERT_THROW(velocity.set_velocity_at(0, 0.0), std::logic_error);
 }
 
 TEST_F(VelocityTest, InvalidGet) {
@@ -57,6 +67,7 @@ TEST_F(VelocityTest, InvalidSet) {
   ASSERT_THROW(velocity1_.set_velocity_at(-1, 1), std::out_of_range);
   ASSERT_THROW(velocity1_.set_velocity_at(7, 1), std::out_of_range);
 }
+
 
 TEST_F(VelocityTest, Addition) {
   VectorXd v1(3), v2(3), d1(3), d2(3);

--- a/src/morphac/constructs/test/velocity_test.cc
+++ b/src/morphac/constructs/test/velocity_test.cc
@@ -40,14 +40,16 @@ TEST_F(VelocityTest, SetVelocity) {
 }
 
 TEST_F(VelocityTest, InvalidConstruction) {
-  ASSERT_THROW(Velocity(0), std::invalid_argument);
-  ASSERT_THROW(Velocity(-1), std::invalid_argument);
+  ASSERT_THROW(Velocity{-1}, std::invalid_argument);
 }
 
 TEST_F(VelocityTest, EmptyConstruction) {
   Velocity velocity;
 
-  // Accessors are invalid for empty velocity
+  // Assert emptiness
+  ASSERT_TRUE(velocity.is_empty());
+
+  // Accessors are invalid for empty Velocity
   ASSERT_THROW(velocity.get_velocity_vector(), std::logic_error);
   ASSERT_THROW(velocity.get_velocity_at(0), std::logic_error);
   ASSERT_THROW(velocity.set_velocity_vector(VectorXd::Random(0)),
@@ -76,8 +78,8 @@ TEST_F(VelocityTest, Addition) {
   d1 << 5, 7, 9;
   d2 << 9, 12, 15;
 
-  Velocity velocity1(v1);
-  Velocity velocity2(v2);
+  Velocity velocity1{v1};
+  Velocity velocity2{v2};
   velocity1 += velocity2;
   ASSERT_TRUE(velocity1.get_velocity_vector().isApprox(d1));
 
@@ -96,8 +98,8 @@ TEST_F(VelocityTest, Subtraction) {
   d1 << -3, -3, -3;
   d2 << -7, -8, -9;
 
-  Velocity velocity1(v1);
-  Velocity velocity2(v2);
+  Velocity velocity1{v1};
+  Velocity velocity2{v2};
   velocity1 -= velocity2;
   ASSERT_TRUE(velocity1.get_velocity_vector().isApprox(d1));
 
@@ -116,8 +118,8 @@ TEST_F(VelocityTest, Multiplication) {
   d1 << 2, 4, 6;
   d2 << -4, -5, -6;
 
-  Velocity velocity1(v1);
-  Velocity velocity2(v2);
+  Velocity velocity1{v1};
+  Velocity velocity2{v2};
 
   velocity1 *= 2.0;
   ASSERT_TRUE(velocity1.get_velocity_vector().isApprox(d1));
@@ -126,6 +128,20 @@ TEST_F(VelocityTest, Multiplication) {
   Velocity velocity4 = -1 * velocity2;
   ASSERT_TRUE(velocity3.get_velocity_vector().isApprox(d2));
   ASSERT_TRUE(velocity4.get_velocity_vector().isApprox(d2));
+}
+
+TEST_F(VelocityTest, EmptyVelocityOperations) {
+  // Basic operations on empty velocities must result in empty velocities.
+  Velocity velocity1, velocity2;
+
+  Velocity velocity_add = velocity1 + velocity2;
+  ASSERT_TRUE(velocity_add.is_empty());
+
+  Velocity velocity_sub = velocity1 - velocity2;
+  ASSERT_TRUE(velocity_sub.is_empty());
+
+  Velocity velocity_mult =  velocity1 * 7.0;
+  ASSERT_TRUE(velocity_mult.is_empty());
 }
 
 }  // namespace

--- a/src/morphac/constructs/test/velocity_test.cc
+++ b/src/morphac/constructs/test/velocity_test.cc
@@ -50,7 +50,8 @@ TEST_F(VelocityTest, EmptyConstruction) {
   // Accessors are invalid for empty velocity
   ASSERT_THROW(velocity.get_velocity_vector(), std::logic_error);
   ASSERT_THROW(velocity.get_velocity_at(0), std::logic_error);
-  ASSERT_THROW(velocity.set_velocity_vector(VectorXd::Random(0)), std::logic_error);
+  ASSERT_THROW(velocity.set_velocity_vector(VectorXd::Random(0)),
+               std::logic_error);
   ASSERT_THROW(velocity.set_velocity_at(0, 0.0), std::logic_error);
 }
 
@@ -67,7 +68,6 @@ TEST_F(VelocityTest, InvalidSet) {
   ASSERT_THROW(velocity1_.set_velocity_at(-1, 1), std::out_of_range);
   ASSERT_THROW(velocity1_.set_velocity_at(7, 1), std::out_of_range);
 }
-
 
 TEST_F(VelocityTest, Addition) {
   VectorXd v1(3), v2(3), d1(3), d2(3);

--- a/src/morphac/constructs/test/velocity_test.cc
+++ b/src/morphac/constructs/test/velocity_test.cc
@@ -53,7 +53,7 @@ TEST_F(VelocityTest, SetVelocity) {
   ASSERT_TRUE(velocity3_.get_velocity_vector().isApprox(v));
 }
 
-TEST_F(VelocityTest, ConstVelocityGet) {
+TEST_F(VelocityTest, ConstVelocity) {
   const Velocity velocity{3};
 
   // For a const Velocity, the values can only be accessed but not set, as a

--- a/src/morphac/constructs/test/velocity_test.cc
+++ b/src/morphac/constructs/test/velocity_test.cc
@@ -25,6 +25,7 @@ class VelocityTest : public ::testing::Test {
 TEST_F(VelocityTest, Sizes) {
   ASSERT_EQ(velocity1_.get_size(), velocity2_.get_size());
   ASSERT_EQ(velocity1_.get_velocity_vector(), velocity2_.get_velocity_vector());
+  ASSERT_EQ(velocity3_.get_size(), 6);
 }
 
 TEST_F(VelocityTest, CopyConstructor) {

--- a/src/morphac/constructs/test/velocity_test.cc
+++ b/src/morphac/constructs/test/velocity_test.cc
@@ -69,7 +69,7 @@ TEST_F(VelocityTest, EmptyConstruction) {
   Velocity velocity;
 
   // Assert emptiness
-  ASSERT_TRUE(velocity.is_empty());
+  ASSERT_TRUE(velocity.IsEmpty());
 
   // Accessors are invalid for empty Velocity
   ASSERT_THROW(velocity.get_velocity_vector(), std::logic_error);
@@ -154,13 +154,13 @@ TEST_F(VelocityTest, EmptyVelocityOperations) {
   Velocity velocity1, velocity2;
 
   Velocity velocity_add = velocity1 + velocity2;
-  ASSERT_TRUE(velocity_add.is_empty());
+  ASSERT_TRUE(velocity_add.IsEmpty());
 
   Velocity velocity_sub = velocity1 - velocity2;
-  ASSERT_TRUE(velocity_sub.is_empty());
+  ASSERT_TRUE(velocity_sub.IsEmpty());
 
   Velocity velocity_mult = velocity1 * 7.0;
-  ASSERT_TRUE(velocity_mult.is_empty());
+  ASSERT_TRUE(velocity_mult.IsEmpty());
 }
 
 TEST_F(VelocityTest, CreateLike) {

--- a/src/morphac/constructs/test/velocity_test.cc
+++ b/src/morphac/constructs/test/velocity_test.cc
@@ -29,14 +29,27 @@ TEST_F(VelocityTest, Sizes) {
 
 TEST_F(VelocityTest, CopyConstructor) {
   ASSERT_EQ(velocity3_.get_size(), velocity4_.get_size());
-  for (int i = 0; i < velocity3_.get_size(); ++i) {
-    ASSERT_EQ(velocity3_.get_velocity_at(i), velocity4_.get_velocity_at(i));
+  ASSERT_TRUE(velocity3_.get_velocity_vector().isApprox(
+      velocity4_.get_velocity_vector()));
+}
+
+TEST_F(VelocityTest, GetVelocity) {
+  ASSERT_TRUE(velocity1_.get_velocity_vector().isApprox(VectorXd::Zero(3)));
+
+  for (int i = 0; i < velocity2_.get_size(); ++i) {
+    ASSERT_EQ(velocity2_(i), 0);
   }
 }
 
 TEST_F(VelocityTest, SetVelocity) {
-  velocity3_.set_velocity_at(1, 7.0);
-  ASSERT_EQ(velocity3_.get_velocity_at(1), 7.0);
+  velocity1_.set_velocity_vector(VectorXd::Ones(3));
+  ASSERT_TRUE(velocity1_.get_velocity_vector().isApprox(VectorXd::Ones(3)));
+
+  VectorXd v = VectorXd::Random(velocity3_.get_size());
+  for (int i = 0; i < velocity3_.get_size(); ++i) {
+    velocity3_(i) = v(i);
+  }
+  ASSERT_TRUE(velocity3_.get_velocity_vector().isApprox(v));
 }
 
 TEST_F(VelocityTest, InvalidConstruction) {
@@ -51,15 +64,14 @@ TEST_F(VelocityTest, EmptyConstruction) {
 
   // Accessors are invalid for empty Velocity
   ASSERT_THROW(velocity.get_velocity_vector(), std::logic_error);
-  ASSERT_THROW(velocity.get_velocity_at(0), std::logic_error);
+  ASSERT_THROW(velocity(0), std::logic_error);
   ASSERT_THROW(velocity.set_velocity_vector(VectorXd::Random(0)),
                std::logic_error);
-  ASSERT_THROW(velocity.set_velocity_at(0, 0.0), std::logic_error);
 }
 
 TEST_F(VelocityTest, InvalidGet) {
-  ASSERT_THROW(velocity1_.get_velocity_at(-1), std::out_of_range);
-  ASSERT_THROW(velocity1_.get_velocity_at(3), std::out_of_range);
+  ASSERT_THROW(velocity1_(-1), std::out_of_range);
+  ASSERT_THROW(velocity1_(3), std::out_of_range);
 }
 
 TEST_F(VelocityTest, InvalidSet) {
@@ -67,8 +79,6 @@ TEST_F(VelocityTest, InvalidSet) {
                std::invalid_argument);
   ASSERT_THROW(velocity1_.set_velocity_vector(VectorXd::Random(2)),
                std::invalid_argument);
-  ASSERT_THROW(velocity1_.set_velocity_at(-1, 1), std::out_of_range);
-  ASSERT_THROW(velocity1_.set_velocity_at(7, 1), std::out_of_range);
 }
 
 TEST_F(VelocityTest, Addition) {
@@ -140,7 +150,7 @@ TEST_F(VelocityTest, EmptyVelocityOperations) {
   Velocity velocity_sub = velocity1 - velocity2;
   ASSERT_TRUE(velocity_sub.is_empty());
 
-  Velocity velocity_mult =  velocity1 * 7.0;
+  Velocity velocity_mult = velocity1 * 7.0;
   ASSERT_TRUE(velocity_mult.is_empty());
 }
 

--- a/src/morphac/constructs/test/velocity_test.cc
+++ b/src/morphac/constructs/test/velocity_test.cc
@@ -53,6 +53,14 @@ TEST_F(VelocityTest, SetVelocity) {
   ASSERT_TRUE(velocity3_.get_velocity_vector().isApprox(v));
 }
 
+TEST_F(VelocityTest, ConstVelocityGet) {
+  const Velocity velocity{3};
+
+  // For a const Velocity, the values can only be accessed but not set, as a
+  // reference (lvalue) is not returned for this overload of the operator.
+  ASSERT_EQ(velocity(0), 0);
+}
+
 TEST_F(VelocityTest, InvalidConstruction) {
   ASSERT_THROW(Velocity{-1}, std::invalid_argument);
 }

--- a/src/morphac/constructs/test/velocity_test.cc
+++ b/src/morphac/constructs/test/velocity_test.cc
@@ -163,6 +163,17 @@ TEST_F(VelocityTest, EmptyVelocityOperations) {
   ASSERT_TRUE(velocity_mult.is_empty());
 }
 
+TEST_F(VelocityTest, CreateLike) {
+  Velocity velocity1 = Velocity::CreateLike(velocity1_);
+  Velocity velocity2 = Velocity::CreateLike(velocity3_);
+
+  ASSERT_EQ(velocity1.get_size(), 3);
+  ASSERT_TRUE(velocity1.get_velocity_vector().isApprox(VectorXd::Zero(3)));
+
+  ASSERT_EQ(velocity2.get_size(), 6);
+  ASSERT_TRUE(velocity2.get_velocity_vector().isApprox(VectorXd::Zero(6)));
+}
+
 }  // namespace
 
 int main(int argc, char **argv) {

--- a/src/morphac/mechanics/CMakeLists.txt
+++ b/src/morphac/mechanics/CMakeLists.txt
@@ -1,12 +1,1 @@
-# Adding libraries
-add_library(kinematic_model ${CMAKE_CURRENT_SOURCE_DIR}/src/kinematic_model.cc)
-target_link_libraries(kinematic_model state control_input)
-
-# Adding test executables
-# Kinematic model test
-add_executable(kinematic_model_test ${CMAKE_CURRENT_SOURCE_DIR}/test/kinematic_model_test.cc)
-target_link_libraries(kinematic_model_test gtest_main kinematic_model)
-add_test(NAME kinematic_model_test COMMAND kinematic_model_test)
-
-
-
+add_subdirectory(models)

--- a/src/morphac/mechanics/models/CMakeLists.txt
+++ b/src/morphac/mechanics/models/CMakeLists.txt
@@ -8,6 +8,9 @@ target_link_libraries(dubin_model kinematic_model state control_input)
 add_library(diffdrive_model ${CMAKE_CURRENT_SOURCE_DIR}/src/diffdrive_model.cc)
 target_link_libraries(diffdrive_model kinematic_model state control_input)
 
+add_library(tricycle_model ${CMAKE_CURRENT_SOURCE_DIR}/src/tricycle_model.cc)
+target_link_libraries(tricycle_model kinematic_model state control_input)
+
 # Adding test executables
 # Kinematic model test
 add_executable(kinematic_model_test ${CMAKE_CURRENT_SOURCE_DIR}/test/kinematic_model_test.cc)
@@ -23,6 +26,11 @@ add_test(NAME dubin_model_test COMMAND dubin_model_test)
 add_executable(diffdrive_model_test ${CMAKE_CURRENT_SOURCE_DIR}/test/diffdrive_model_test.cc)
 target_link_libraries(diffdrive_model_test gtest_main diffdrive_model)
 add_test(NAME diffdrive_model_test COMMAND diffdrive_model_test)
+
+# Tricycle model test
+add_executable(tricycle_model_test ${CMAKE_CURRENT_SOURCE_DIR}/test/tricycle_model_test.cc)
+target_link_libraries(tricycle_model_test gtest_main tricycle_model)
+add_test(NAME tricycle_model_test COMMAND tricycle_model_test)
 
 
 

--- a/src/morphac/mechanics/models/CMakeLists.txt
+++ b/src/morphac/mechanics/models/CMakeLists.txt
@@ -11,5 +11,11 @@ add_executable(kinematic_model_test ${CMAKE_CURRENT_SOURCE_DIR}/test/kinematic_m
 target_link_libraries(kinematic_model_test gtest_main kinematic_model)
 add_test(NAME kinematic_model_test COMMAND kinematic_model_test)
 
+# Dubin model test
+add_executable(dubin_model_test ${CMAKE_CURRENT_SOURCE_DIR}/test/dubin_model_test.cc)
+target_link_libraries(dubin_model_test gtest_main dubin_model)
+add_test(NAME dubin_model_test COMMAND dubin_model_test)
+
+
 
 

--- a/src/morphac/mechanics/models/CMakeLists.txt
+++ b/src/morphac/mechanics/models/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Adding libraries
+add_library(kinematic_model ${CMAKE_CURRENT_SOURCE_DIR}/src/kinematic_model.cc)
+target_link_libraries(kinematic_model state control_input)
+
+# Adding test executables
+# Kinematic model test
+add_executable(kinematic_model_test ${CMAKE_CURRENT_SOURCE_DIR}/test/kinematic_model_test.cc)
+target_link_libraries(kinematic_model_test gtest_main kinematic_model)
+add_test(NAME kinematic_model_test COMMAND kinematic_model_test)
+
+
+

--- a/src/morphac/mechanics/models/CMakeLists.txt
+++ b/src/morphac/mechanics/models/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library(kinematic_model ${CMAKE_CURRENT_SOURCE_DIR}/src/kinematic_model.cc)
 target_link_libraries(kinematic_model state control_input)
 
 add_library(dubin_model ${CMAKE_CURRENT_SOURCE_DIR}/src/dubin_model.cc)
-target_link_libraries(dubin_model kinematic_model)
+target_link_libraries(dubin_model kinematic_model state control_input)
 
 # Adding test executables
 # Kinematic model test

--- a/src/morphac/mechanics/models/CMakeLists.txt
+++ b/src/morphac/mechanics/models/CMakeLists.txt
@@ -19,6 +19,13 @@ add_executable(dubin_model_test ${CMAKE_CURRENT_SOURCE_DIR}/test/dubin_model_tes
 target_link_libraries(dubin_model_test gtest_main dubin_model)
 add_test(NAME dubin_model_test COMMAND dubin_model_test)
 
+# Diffdrive model test
+add_executable(diffdrive_model_test ${CMAKE_CURRENT_SOURCE_DIR}/test/diffdrive_model_test.cc)
+target_link_libraries(diffdrive_model_test gtest_main diffdrive_model)
+add_test(NAME diffdrive_model_test COMMAND diffdrive_model_test)
+
+
+
 
 
 

--- a/src/morphac/mechanics/models/CMakeLists.txt
+++ b/src/morphac/mechanics/models/CMakeLists.txt
@@ -5,6 +5,9 @@ target_link_libraries(kinematic_model state control_input)
 add_library(dubin_model ${CMAKE_CURRENT_SOURCE_DIR}/src/dubin_model.cc)
 target_link_libraries(dubin_model kinematic_model state control_input)
 
+add_library(diffdrive_model ${CMAKE_CURRENT_SOURCE_DIR}/src/diffdrive_model.cc)
+target_link_libraries(diffdrive_model kinematic_model state control_input)
+
 # Adding test executables
 # Kinematic model test
 add_executable(kinematic_model_test ${CMAKE_CURRENT_SOURCE_DIR}/test/kinematic_model_test.cc)

--- a/src/morphac/mechanics/models/CMakeLists.txt
+++ b/src/morphac/mechanics/models/CMakeLists.txt
@@ -2,6 +2,9 @@
 add_library(kinematic_model ${CMAKE_CURRENT_SOURCE_DIR}/src/kinematic_model.cc)
 target_link_libraries(kinematic_model state control_input)
 
+add_library(dubin_model ${CMAKE_CURRENT_SOURCE_DIR}/src/dubin_model.cc)
+target_link_libraries(dubin_model kinematic_model)
+
 # Adding test executables
 # Kinematic model test
 add_executable(kinematic_model_test ${CMAKE_CURRENT_SOURCE_DIR}/test/kinematic_model_test.cc)

--- a/src/morphac/mechanics/models/include/diffdrive_model.h
+++ b/src/morphac/mechanics/models/include/diffdrive_model.h
@@ -1,0 +1,34 @@
+#ifndef DIFFDRIVE_MODEL_H
+#define DIFFDRIVE_MODEL_H
+
+#include "Eigen/Dense"
+
+#include "common/error_handling/include/error_macros.h"
+#include "constructs/include/control_input.h"
+#include "constructs/include/state.h"
+#include "mechanics/models/include/kinematic_model.h"
+
+namespace morphac {
+namespace mechanics {
+namespace models {
+
+class DiffDriveModel : public morphac::mechanics::models::KinematicModel {
+ public:
+  DiffDriveModel(const std::string name, const double radius,
+                 const double length);
+  void ComputeStateDerivative(const morphac::constructs::State& state,
+                              const morphac::constructs::ControlInput& input,
+                              morphac::constructs::State& derivative) const;
+  morphac::constructs::State ComputeStateDerivative(
+      const morphac::constructs::State& state,
+      const morphac::constructs::ControlInput& input) const;
+
+  const double radius;
+  const double length;
+};
+
+}  // namespace models
+}  // namespace mechancis
+}  // namespace morphac
+
+#endif

--- a/src/morphac/mechanics/models/include/dubin_model.h
+++ b/src/morphac/mechanics/models/include/dubin_model.h
@@ -1,0 +1,9 @@
+#ifndef DUBIN_MODEL_H
+#define DUBIN_MODEL_H
+
+namespace morphac {
+namespace mechanics {
+
+} // namespace constructs
+} // namespace morphac
+

--- a/src/morphac/mechanics/models/include/dubin_model.h
+++ b/src/morphac/mechanics/models/include/dubin_model.h
@@ -7,11 +7,18 @@
 
 namespace morphac {
 namespace mechanics {
+namespace models {
 
-class DubinModel : public KinematicModel {
-  public:
-    DubinModel(const std::string_name="dubin_model") : KinematicModel(
+class DubinModel : public morphac::mechanics::models::KinematicModel {
+ public:
+  DubinModel(const std::string name, const double speed);
 
-} // namespace constructs
-} // namespace morphac
+  const double speed;
+};
+
+}  // namespace models
+}  // namespace constructs
+}  // namespace morphac
+
+#endif
 

--- a/src/morphac/mechanics/models/include/dubin_model.h
+++ b/src/morphac/mechanics/models/include/dubin_model.h
@@ -18,10 +18,10 @@ class DubinModel : public morphac::mechanics::models::KinematicModel {
 
   void ComputeStateDerivative(const morphac::constructs::State& state,
                               const morphac::constructs::ControlInput& input,
-                              morphac::constructs::State& derivative) const = 0;
+                              morphac::constructs::State& derivative) const;
   morphac::constructs::State ComputeStateDerivative(
       const morphac::constructs::State& state,
-      const morphac::constructs::ControlInput& input) const = 0;
+      const morphac::constructs::ControlInput& input) const;
 
   const double speed;
 };

--- a/src/morphac/mechanics/models/include/dubin_model.h
+++ b/src/morphac/mechanics/models/include/dubin_model.h
@@ -4,6 +4,8 @@
 #include "Eigen/Dense"
 
 #include "mechanics/models/include/kinematic_model.h"
+#include "constructs/include/control_input.h"
+#include "constructs/include/state.h"
 
 namespace morphac {
 namespace mechanics {
@@ -12,6 +14,13 @@ namespace models {
 class DubinModel : public morphac::mechanics::models::KinematicModel {
  public:
   DubinModel(const std::string name, const double speed);
+
+  void ComputeStateDerivative(const morphac::constructs::State& state,
+                              const morphac::constructs::ControlInput& input,
+                              morphac::constructs::State& derivative) const = 0;
+  morphac::constructs::State ComputeStateDerivative(
+      const morphac::constructs::State& state,
+      const morphac::constructs::ControlInput& input) const = 0;
 
   const double speed;
 };

--- a/src/morphac/mechanics/models/include/dubin_model.h
+++ b/src/morphac/mechanics/models/include/dubin_model.h
@@ -16,12 +16,13 @@ class DubinModel : public morphac::mechanics::models::KinematicModel {
  public:
   DubinModel(const std::string name, const double speed);
 
-  void ComputeStateDerivative(const morphac::constructs::State& state,
-                              const morphac::constructs::ControlInput& input,
-                              morphac::constructs::State& derivative) const;
+  void ComputeStateDerivative(
+      const morphac::constructs::State& state,
+      const morphac::constructs::ControlInput& input,
+      morphac::constructs::State& derivative) const override;
   morphac::constructs::State ComputeStateDerivative(
       const morphac::constructs::State& state,
-      const morphac::constructs::ControlInput& input) const;
+      const morphac::constructs::ControlInput& input) const override;
 
   const double speed;
 };

--- a/src/morphac/mechanics/models/include/dubin_model.h
+++ b/src/morphac/mechanics/models/include/dubin_model.h
@@ -3,9 +3,10 @@
 
 #include "Eigen/Dense"
 
-#include "mechanics/models/include/kinematic_model.h"
+#include "common/error_handling/include/error_macros.h"
 #include "constructs/include/control_input.h"
 #include "constructs/include/state.h"
+#include "mechanics/models/include/kinematic_model.h"
 
 namespace morphac {
 namespace mechanics {

--- a/src/morphac/mechanics/models/include/dubin_model.h
+++ b/src/morphac/mechanics/models/include/dubin_model.h
@@ -1,8 +1,16 @@
 #ifndef DUBIN_MODEL_H
 #define DUBIN_MODEL_H
 
+#include "Eigen/Dense"
+
+#include "mechanics/models/include/kinematic_model.h"
+
 namespace morphac {
 namespace mechanics {
+
+class DubinModel : public KinematicModel {
+  public:
+    DubinModel(const std::string_name="dubin_model") : KinematicModel(
 
 } // namespace constructs
 } // namespace morphac

--- a/src/morphac/mechanics/models/include/kinematic_model.h
+++ b/src/morphac/mechanics/models/include/kinematic_model.h
@@ -10,6 +10,7 @@
 
 namespace morphac {
 namespace mechanics {
+namespace models {
 
 // The parameters of this class need to be kept const as they serve as a kind
 // of data class as well. Nothing is private to prevent unnecessary private
@@ -38,6 +39,7 @@ class KinematicModel {
   const int size_input;
 };
 
+}  // namespace models
 }  // namespace constructs
 }  // namespace morphac
 

--- a/src/morphac/mechanics/models/include/kinematic_model.h
+++ b/src/morphac/mechanics/models/include/kinematic_model.h
@@ -29,10 +29,6 @@ class KinematicModel {
       const morphac::constructs::ControlInput& input,
       morphac::constructs::State& derivative) const = 0;
 
-  const int get_size_pose() const;
-  const int get_size_velocity() const;
-  const int get_size_input() const;
-
   const std::string name;
   const int size_pose;
   const int size_velocity;
@@ -40,7 +36,7 @@ class KinematicModel {
 };
 
 }  // namespace models
-}  // namespace constructs
+}  // namespace mechanics
 }  // namespace morphac
 
 #endif

--- a/src/morphac/mechanics/models/include/kinematic_model.h
+++ b/src/morphac/mechanics/models/include/kinematic_model.h
@@ -23,9 +23,9 @@ class KinematicModel {
       const morphac::constructs::State& state,
       const morphac::constructs::ControlInput& input,
       morphac::constructs::State& derivative) const = 0;
-  morphac::constructs::State ComputeStateDerivative(
+  virtual morphac::constructs::State ComputeStateDerivative(
       const morphac::constructs::State& state,
-      const morphac::constructs::ControlInput& input) const;
+      const morphac::constructs::ControlInput& input) const = 0;
 
   const std::string name;
   const int size_pose;

--- a/src/morphac/mechanics/models/include/kinematic_model.h
+++ b/src/morphac/mechanics/models/include/kinematic_model.h
@@ -23,9 +23,9 @@ class KinematicModel {
       const morphac::constructs::State& state,
       const morphac::constructs::ControlInput& input,
       morphac::constructs::State& derivative) const = 0;
-  virtual morphac::constructs::State ComputeStateDerivative(
+  morphac::constructs::State ComputeStateDerivative(
       const morphac::constructs::State& state,
-      const morphac::constructs::ControlInput& input) const = 0;
+      const morphac::constructs::ControlInput& input) const;
 
   const std::string name;
   const int size_pose;

--- a/src/morphac/mechanics/models/include/kinematic_model.h
+++ b/src/morphac/mechanics/models/include/kinematic_model.h
@@ -4,9 +4,7 @@
 #include "Eigen/Dense"
 
 #include "constructs/include/control_input.h"
-#include "constructs/include/pose.h"
 #include "constructs/include/state.h"
-#include "constructs/include/velocity.h"
 
 namespace morphac {
 namespace mechanics {
@@ -21,13 +19,13 @@ class KinematicModel {
   KinematicModel(const std::string name, const int size_pose,
                  const int size_velocity, const int size_input);
 
-  virtual morphac::constructs::State ComputeStateDerivative(
-      const morphac::constructs::State& state,
-      const morphac::constructs::ControlInput& input) const = 0;
   virtual void ComputeStateDerivative(
       const morphac::constructs::State& state,
       const morphac::constructs::ControlInput& input,
       morphac::constructs::State& derivative) const = 0;
+  virtual morphac::constructs::State ComputeStateDerivative(
+      const morphac::constructs::State& state,
+      const morphac::constructs::ControlInput& input) const = 0;
 
   const std::string name;
   const int size_pose;

--- a/src/morphac/mechanics/models/include/kinematic_model.h
+++ b/src/morphac/mechanics/models/include/kinematic_model.h
@@ -1,8 +1,6 @@
 #ifndef KINEMATIC_MODEL_H
 #define KINEMATIC_MODEL_H
 
-#include <unordered_map>
-
 #include "Eigen/Dense"
 
 #include "constructs/include/control_input.h"

--- a/src/morphac/mechanics/models/include/tricycle_model.h
+++ b/src/morphac/mechanics/models/include/tricycle_model.h
@@ -1,0 +1,34 @@
+#ifndef TRICYCLE_MODEL_H
+#define TRICYCLE_MODEL_H
+
+#include "Eigen/Dense"
+
+#include "common/error_handling/include/error_macros.h"
+#include "constructs/include/control_input.h"
+#include "constructs/include/state.h"
+#include "mechanics/models/include/kinematic_model.h"
+
+namespace morphac {
+namespace mechanics {
+namespace models {
+
+class TricycleModel : public morphac::mechanics::models::KinematicModel {
+ public:
+  TricycleModel(const std::string name, const double radius,
+                const double length);
+  void ComputeStateDerivative(const morphac::constructs::State& state,
+                              const morphac::constructs::ControlInput& input,
+                              morphac::constructs::State& derivative) const;
+  morphac::constructs::State ComputeStateDerivative(
+      const morphac::constructs::State& state,
+      const morphac::constructs::ControlInput& input) const;
+
+  const double radius;
+  const double length;
+};
+
+}  // namespace models
+}  // namespace mechancis
+}  // namespace morphac
+
+#endif

--- a/src/morphac/mechanics/models/src/diffdrive_model.cc
+++ b/src/morphac/mechanics/models/src/diffdrive_model.cc
@@ -18,7 +18,12 @@ using morphac::constructs::Pose;
 
 DiffDriveModel::DiffDriveModel(const string name, const double radius,
                                const double length)
-    : KinematicModel(name, 3, 0, 2), radius(radius), length(length) {}
+    : KinematicModel(name, 3, 0, 2), radius(radius), length(length) {
+  MORPH_REQUIRE(radius > 0, std::invalid_argument,
+                "Diffdrive wheel radius must be positive.");
+  MORPH_REQUIRE(length > 0, std::invalid_argument,
+                "Diffdrive distance between the wheels must be positive.");
+}
 
 void DiffDriveModel::ComputeStateDerivative(const State& state,
                                             const ControlInput& input,
@@ -39,7 +44,7 @@ void DiffDriveModel::ComputeStateDerivative(const State& state,
   double theta = state.get_pose()(2);
 
   MatrixXd F = VectorXd::Zero(3);
-  MatrixXd G(2, 3);
+  MatrixXd G(3, 2);
 
   G << radius * 0.5 * cos(theta), radius * 0.5 * cos(theta),
       radius * 0.5 * sin(theta), radius * 0.5 * sin(theta), -radius / length,

--- a/src/morphac/mechanics/models/src/diffdrive_model.cc
+++ b/src/morphac/mechanics/models/src/diffdrive_model.cc
@@ -16,7 +16,13 @@ using morphac::constructs::ControlInput;
 using morphac::constructs::State;
 using morphac::constructs::Pose;
 
-} // namespace models
-} // namespace mechanics
-} // namespace morphac
+DiffDriveModel::DiffDriveModel(const string name, const double radius,
+                               const double length)
+    : KinematicModel(name, 3, 0, 2), radius(radius), length(length) {}
+
+
+
+}  // namespace models
+}  // namespace mechanics
+}  // namespace morphac
 

--- a/src/morphac/mechanics/models/src/diffdrive_model.cc
+++ b/src/morphac/mechanics/models/src/diffdrive_model.cc
@@ -40,9 +40,11 @@ void DiffDriveModel::ComputeStateDerivative(const State& state,
       "Pose component of the derivative needs to be of size 3 [x, y, theta]");
   MORPH_REQUIRE(derivative.IsVelocityEmpty(), std::invalid_argument,
                 "Velocity component of the derivative must be empty.");
+
   VectorXd pose_derivative(3);
   double theta = state.get_pose()(2);
 
+  // Equation of the form xdot = F(x) + G(x)u
   MatrixXd F = VectorXd::Zero(3);
   MatrixXd G(3, 2);
 

--- a/src/morphac/mechanics/models/src/diffdrive_model.cc
+++ b/src/morphac/mechanics/models/src/diffdrive_model.cc
@@ -1,0 +1,22 @@
+#include "mechanics/models/include/diffdrive_model.h"
+
+namespace morphac {
+namespace mechanics {
+namespace models {
+
+using std::cos;
+using std::sin;
+using std::string;
+
+using Eigen::MatrixXd;
+using Eigen::VectorXd;
+
+using morphac::mechanics::models::KinematicModel;
+using morphac::constructs::ControlInput;
+using morphac::constructs::State;
+using morphac::constructs::Pose;
+
+} // namespace models
+} // namespace mechanics
+} // namespace morphac
+

--- a/src/morphac/mechanics/models/src/diffdrive_model.cc
+++ b/src/morphac/mechanics/models/src/diffdrive_model.cc
@@ -37,6 +37,24 @@ void DiffDriveModel::ComputeStateDerivative(const State& state,
                 "Velocity component of the derivative must be empty.");
   VectorXd pose_derivative(3);
   double theta = state.get_pose()(2);
+
+  MatrixXd F = VectorXd::Zero(3);
+  MatrixXd G(2, 3);
+
+  G << radius * 0.5 * cos(theta), radius * 0.5 * cos(theta),
+      radius * 0.5 * sin(theta), radius * 0.5 * sin(theta), -radius / length,
+      radius / length;
+
+  pose_derivative = F + G * input.get_input_vector();
+  derivative.set_pose_vector(pose_derivative);
+}
+
+State DiffDriveModel::ComputeStateDerivative(const State& state,
+                                             const ControlInput& input) const {
+  // Argument checks are performed by the other overloaded function.
+  State derivative = State::CreateLike(state);
+  ComputeStateDerivative(state, input, derivative);
+  return derivative;
 }
 
 }  // namespace models

--- a/src/morphac/mechanics/models/src/diffdrive_model.cc
+++ b/src/morphac/mechanics/models/src/diffdrive_model.cc
@@ -20,7 +20,24 @@ DiffDriveModel::DiffDriveModel(const string name, const double radius,
                                const double length)
     : KinematicModel(name, 3, 0, 2), radius(radius), length(length) {}
 
-
+void DiffDriveModel::ComputeStateDerivative(const State& state,
+                                            const ControlInput& input,
+                                            State& derivative) const {
+  MORPH_REQUIRE(
+      state.get_size_pose() == 3, std::invalid_argument,
+      "Pose component of the state needs to be of size 3 [x, y, theta]");
+  MORPH_REQUIRE(state.is_velocity_empty(), std::invalid_argument,
+                "Velocity component of the state must be empty.");
+  MORPH_REQUIRE(input.get_size() == 2, std::invalid_argument,
+                "Control input must be of size 1.");
+  MORPH_REQUIRE(
+      derivative.get_size_pose() == 3, std::invalid_argument,
+      "Pose component of the derivative needs to be of size 3 [x, y, theta]");
+  MORPH_REQUIRE(derivative.is_velocity_empty(), std::invalid_argument,
+                "Velocity component of the derivative must be empty.");
+  VectorXd pose_derivative(3);
+  double theta = state.get_pose()(2);
+}
 
 }  // namespace models
 }  // namespace mechanics

--- a/src/morphac/mechanics/models/src/diffdrive_model.cc
+++ b/src/morphac/mechanics/models/src/diffdrive_model.cc
@@ -31,14 +31,14 @@ void DiffDriveModel::ComputeStateDerivative(const State& state,
   MORPH_REQUIRE(
       state.get_size_pose() == 3, std::invalid_argument,
       "Pose component of the state needs to be of size 3 [x, y, theta]");
-  MORPH_REQUIRE(state.is_velocity_empty(), std::invalid_argument,
+  MORPH_REQUIRE(state.IsVelocityEmpty(), std::invalid_argument,
                 "Velocity component of the state must be empty.");
   MORPH_REQUIRE(input.get_size() == 2, std::invalid_argument,
                 "Control input must be of size 1.");
   MORPH_REQUIRE(
       derivative.get_size_pose() == 3, std::invalid_argument,
       "Pose component of the derivative needs to be of size 3 [x, y, theta]");
-  MORPH_REQUIRE(derivative.is_velocity_empty(), std::invalid_argument,
+  MORPH_REQUIRE(derivative.IsVelocityEmpty(), std::invalid_argument,
                 "Velocity component of the derivative must be empty.");
   VectorXd pose_derivative(3);
   double theta = state.get_pose()(2);

--- a/src/morphac/mechanics/models/src/dubin_model.cc
+++ b/src/morphac/mechanics/models/src/dubin_model.cc
@@ -38,7 +38,7 @@ void DubinModel::ComputeStateDerivative(const State& state,
 
   // Equation of the form xdot = F(x) + G(x)u
   MatrixXd F(3, 1), G(3, 1);
-  F << speed * cos(theta) , speed * sin(theta), 0;
+  F << speed * cos(theta), speed * sin(theta), 0;
   G << 0, 0, 1;
 
   pose_derivative = F + G * input.get_input_vector();
@@ -47,14 +47,8 @@ void DubinModel::ComputeStateDerivative(const State& state,
 
 State DubinModel::ComputeStateDerivative(const State& state,
                                          const ControlInput& input) const {
-  MORPH_REQUIRE(
-      state.get_size_pose() == 3, std::invalid_argument,
-      "Pose component of the state needs to be of size 3 [x, y, theta]");
-  MORPH_REQUIRE(state.is_velocity_empty(), std::invalid_argument,
-                "Velocity component of the state must be empty.");
-  MORPH_REQUIRE(input.get_size() == 1, std::invalid_argument,
-                "Control input must be of size 1.");
-  State derivative(3, 0);
+  // Argument checks are performed by the other overloaded function.
+  State derivative = State::CreateLike(state);
   ComputeStateDerivative(state, input, derivative);
   return derivative;
 }

--- a/src/morphac/mechanics/models/src/dubin_model.cc
+++ b/src/morphac/mechanics/models/src/dubin_model.cc
@@ -8,12 +8,12 @@ using std::cos;
 using std::sin;
 using std::string;
 
+using Eigen::MatrixXd;
 using Eigen::VectorXd;
 
 using morphac::mechanics::models::KinematicModel;
 using morphac::constructs::ControlInput;
 using morphac::constructs::State;
-using morphac::constructs::Pose;
 
 DubinModel::DubinModel(const string name, const double speed)
     : KinematicModel(name, 3, 0, 1), speed(speed) {}
@@ -35,9 +35,13 @@ void DubinModel::ComputeStateDerivative(const State& state,
                 "Velocity component of the derivative must be empty.");
   VectorXd pose_derivative(3);
   double theta = state.get_pose()(2);
-  Pose pose = state.get_pose();
 
-  pose_derivative << speed * cos(theta), speed * sin(theta), input(0);
+  // Equation of the form xdot = F(x) + G(x)u
+  MatrixXd F(3, 1), G(3, 1);
+  F << speed * cos(theta) , speed * sin(theta), 0;
+  G << 0, 0, 1;
+
+  pose_derivative = F + G * input.get_input_vector();
   derivative.set_pose_vector(pose_derivative);
 }
 

--- a/src/morphac/mechanics/models/src/dubin_model.cc
+++ b/src/morphac/mechanics/models/src/dubin_model.cc
@@ -13,6 +13,7 @@ using Eigen::VectorXd;
 using morphac::mechanics::models::KinematicModel;
 using morphac::constructs::ControlInput;
 using morphac::constructs::State;
+using morphac::constructs::Pose;
 
 DubinModel::DubinModel(const string name, const double speed)
     : KinematicModel(name, 3, 3, 1), speed(speed) {}
@@ -33,10 +34,10 @@ void DubinModel::ComputeStateDerivative(const State& state,
   MORPH_REQUIRE(derivative.is_velocity_empty(), std::invalid_argument,
                 "Velocity component of the derivative must be empty.");
   VectorXd pose_derivative(3);
-  double theta = state(3);
+  double theta = state.get_pose()(2);
+  Pose pose = state.get_pose();
 
-  pose_derivative << speed * cos(theta), speed * sin(theta),
-      input(0);
+  pose_derivative << speed * cos(theta), speed * sin(theta), input(0);
   derivative.set_pose_vector(pose_derivative);
 }
 

--- a/src/morphac/mechanics/models/src/dubin_model.cc
+++ b/src/morphac/mechanics/models/src/dubin_model.cc
@@ -33,10 +33,10 @@ void DubinModel::ComputeStateDerivative(const State& state,
   MORPH_REQUIRE(derivative.is_velocity_empty(), std::invalid_argument,
                 "Velocity component of the derivative must be empty.");
   VectorXd pose_derivative(3);
-  double theta = state.get_pose_at(3);
+  double theta = state(3);
 
   pose_derivative << speed * cos(theta), speed * sin(theta),
-      input.get_input_at(0);
+      input(0);
   derivative.set_pose_vector(pose_derivative);
 }
 

--- a/src/morphac/mechanics/models/src/dubin_model.cc
+++ b/src/morphac/mechanics/models/src/dubin_model.cc
@@ -4,6 +4,8 @@ namespace morphac {
 namespace mechanics {
 namespace models {
 
+using std::cos;
+using std::sin;
 using std::string;
 
 using Eigen::VectorXd;
@@ -18,11 +20,39 @@ DubinModel::DubinModel(const string name, const double speed)
 void DubinModel::ComputeStateDerivative(const State& state,
                                         const ControlInput& input,
                                         State& derivative) const {
-  VectorXd pose_derivative(3), velocity_derivative(3);
+  MORPH_REQUIRE(
+      state.get_size_pose() == 3, std::invalid_argument,
+      "Pose component of the state needs to be of size 3 [x, y, theta]");
+  MORPH_REQUIRE(state.is_velocity_empty(), std::invalid_argument,
+                "Velocity component of the state must be empty.");
+  MORPH_REQUIRE(input.get_size() == 1, std::invalid_argument,
+                "Control input must be of size 1.");
+  MORPH_REQUIRE(
+      derivative.get_size_pose() == 3, std::invalid_argument,
+      "Pose component of the derivative needs to be of size 3 [x, y, theta]");
+  MORPH_REQUIRE(derivative.is_velocity_empty(), std::invalid_argument,
+                "Velocity component of the derivative must be empty.");
+  VectorXd pose_derivative(3);
+  double theta = state.get_pose_at(3);
+
+  pose_derivative << speed * cos(theta), speed * sin(theta),
+      input.get_input_at(0);
+  derivative.set_pose_vector(pose_derivative);
 }
 
 State DubinModel::ComputeStateDerivative(const State& state,
-                                         const ControlInput& input) const {}
+                                         const ControlInput& input) const {
+  MORPH_REQUIRE(
+      state.get_size_pose() == 3, std::invalid_argument,
+      "Pose component of the state needs to be of size 3 [x, y, theta]");
+  MORPH_REQUIRE(state.is_velocity_empty(), std::invalid_argument,
+                "Velocity component of the state must be empty.");
+  MORPH_REQUIRE(input.get_size() == 1, std::invalid_argument,
+                "Control input must be of size 1.");
+  State derivative(3, 0);
+  ComputeStateDerivative(state, input, derivative);
+  return derivative;
+}
 
 }  // namespace models
 }  // namespace mechanics

--- a/src/morphac/mechanics/models/src/dubin_model.cc
+++ b/src/morphac/mechanics/models/src/dubin_model.cc
@@ -16,7 +16,7 @@ using morphac::constructs::State;
 using morphac::constructs::Pose;
 
 DubinModel::DubinModel(const string name, const double speed)
-    : KinematicModel(name, 3, 3, 1), speed(speed) {}
+    : KinematicModel(name, 3, 0, 1), speed(speed) {}
 
 void DubinModel::ComputeStateDerivative(const State& state,
                                         const ControlInput& input,

--- a/src/morphac/mechanics/models/src/dubin_model.cc
+++ b/src/morphac/mechanics/models/src/dubin_model.cc
@@ -1,0 +1,16 @@
+#include "mechanics/models/include/dubin_model.h"
+
+namespace morphac {
+namespace mechanics {
+namespace models {
+
+using std::string;
+
+using morphac::mechanics::models::KinematicModel;
+
+DubinModel::DubinModel(const string name, const double speed)
+    : KinematicModel(name, 3, 3, 1), speed(speed) {}
+
+}  // namespace models
+}  // namespace mechanics
+}  // namespace morphac

--- a/src/morphac/mechanics/models/src/dubin_model.cc
+++ b/src/morphac/mechanics/models/src/dubin_model.cc
@@ -6,10 +6,23 @@ namespace models {
 
 using std::string;
 
+using Eigen::VectorXd;
+
 using morphac::mechanics::models::KinematicModel;
+using morphac::constructs::ControlInput;
+using morphac::constructs::State;
 
 DubinModel::DubinModel(const string name, const double speed)
     : KinematicModel(name, 3, 3, 1), speed(speed) {}
+
+void DubinModel::ComputeStateDerivative(const State& state,
+                                        const ControlInput& input,
+                                        State& derivative) const {
+  VectorXd pose_derivative(3), velocity_derivative(3);
+}
+
+State DubinModel::ComputeStateDerivative(const State& state,
+                                         const ControlInput& input) const {}
 
 }  // namespace models
 }  // namespace mechanics

--- a/src/morphac/mechanics/models/src/dubin_model.cc
+++ b/src/morphac/mechanics/models/src/dubin_model.cc
@@ -24,14 +24,14 @@ void DubinModel::ComputeStateDerivative(const State& state,
   MORPH_REQUIRE(
       state.get_size_pose() == 3, std::invalid_argument,
       "Pose component of the state needs to be of size 3 [x, y, theta]");
-  MORPH_REQUIRE(state.is_velocity_empty(), std::invalid_argument,
+  MORPH_REQUIRE(state.IsVelocityEmpty(), std::invalid_argument,
                 "Velocity component of the state must be empty.");
   MORPH_REQUIRE(input.get_size() == 1, std::invalid_argument,
                 "Control input must be of size 1.");
   MORPH_REQUIRE(
       derivative.get_size_pose() == 3, std::invalid_argument,
       "Pose component of the derivative needs to be of size 3 [x, y, theta]");
-  MORPH_REQUIRE(derivative.is_velocity_empty(), std::invalid_argument,
+  MORPH_REQUIRE(derivative.IsVelocityEmpty(), std::invalid_argument,
                 "Velocity component of the derivative must be empty.");
   VectorXd pose_derivative(3);
   double theta = state.get_pose()(2);

--- a/src/morphac/mechanics/models/src/kinematic_model.cc
+++ b/src/morphac/mechanics/models/src/kinematic_model.cc
@@ -4,8 +4,6 @@ namespace morphac {
 namespace mechanics {
 namespace models {
 
-using std::make_shared;
-using std::shared_ptr;
 using std::string;
 
 using morphac::constructs::ControlInput;
@@ -13,14 +11,14 @@ using morphac::constructs::Pose;
 using morphac::constructs::State;
 using morphac::constructs::Velocity;
 
-KinematicModel::KinematicModel(string name, int size_pose, int size_velocity,
-                               int size_input)
+KinematicModel::KinematicModel(const string name, const int size_pose,
+                               const int size_velocity, const int size_input)
     : name(name),
       size_pose(size_pose),
       size_velocity(size_velocity),
       size_input(size_input) {}
 
 }  // models
-}  // constructs
+}  // mechanics
 }  // morphac
 

--- a/src/morphac/mechanics/models/src/kinematic_model.cc
+++ b/src/morphac/mechanics/models/src/kinematic_model.cc
@@ -18,6 +18,10 @@ KinematicModel::KinematicModel(const string name, const int size_pose,
       size_velocity(size_velocity),
       size_input(size_input) {}
 
+State ComputeStateDerivative(const State& state,
+                             const ControlInput& input) const {
+}
+
 }  // models
 }  // mechanics
 }  // morphac

--- a/src/morphac/mechanics/models/src/kinematic_model.cc
+++ b/src/morphac/mechanics/models/src/kinematic_model.cc
@@ -2,6 +2,7 @@
 
 namespace morphac {
 namespace mechanics {
+namespace models {
 
 using std::make_shared;
 using std::shared_ptr;
@@ -19,6 +20,7 @@ KinematicModel::KinematicModel(string name, int size_pose, int size_velocity,
       size_velocity(size_velocity),
       size_input(size_input) {}
 
+}  // models
 }  // constructs
 }  // morphac
 

--- a/src/morphac/mechanics/models/src/kinematic_model.cc
+++ b/src/morphac/mechanics/models/src/kinematic_model.cc
@@ -18,10 +18,6 @@ KinematicModel::KinematicModel(const string name, const int size_pose,
       size_velocity(size_velocity),
       size_input(size_input) {}
 
-State ComputeStateDerivative(const State& state,
-                             const ControlInput& input) const {
-}
-
 }  // models
 }  // mechanics
 }  // morphac

--- a/src/morphac/mechanics/models/src/kinematic_model.cc
+++ b/src/morphac/mechanics/models/src/kinematic_model.cc
@@ -1,4 +1,4 @@
-#include "mechanics/include/kinematic_model.h"
+#include "mechanics/models/include/kinematic_model.h"
 
 namespace morphac {
 namespace mechanics {

--- a/src/morphac/mechanics/models/src/tricycle_model.cc
+++ b/src/morphac/mechanics/models/src/tricycle_model.cc
@@ -47,7 +47,7 @@ void TricycleModel::ComputeStateDerivative(const State& state,
   double alpha = state.get_pose()(3);
 
   // Equation of the form xdot = F(x) + G(x)u
-  MatrixXd F = VectorXd::Zero(3);
+  MatrixXd F = VectorXd::Zero(4);
   MatrixXd G(4, 2);
 
   G << radius * cos(alpha) * cos(theta), 0, radius * cos(alpha) * sin(theta), 0,
@@ -57,7 +57,8 @@ void TricycleModel::ComputeStateDerivative(const State& state,
   derivative.set_pose_vector(pose_derivative);
 }
 
-State TricycleModel::ComputeStateDerivative(const State& state, const ControlInput& input) const {
+State TricycleModel::ComputeStateDerivative(const State& state,
+                                            const ControlInput& input) const {
   // Argument checks are performed by the other overloaded function.
   State derivative = State::CreateLike(state);
   ComputeStateDerivative(state, input, derivative);

--- a/src/morphac/mechanics/models/src/tricycle_model.cc
+++ b/src/morphac/mechanics/models/src/tricycle_model.cc
@@ -1,0 +1,32 @@
+#include "mechanics/models/include/tricycle_model.h"
+
+namespace morphac {
+namespace mechanics {
+namespace models {
+
+using std::cos;
+using std::sin;
+using std::string;
+
+using Eigen::MatrixXd;
+using Eigen::VectorXd;
+
+using morphac::mechanics::models::KinematicModel;
+using morphac::constructs::ControlInput;
+using morphac::constructs::State;
+using morphac::constructs::Pose;
+
+TricycleModel::TricycleModel(const string name, const double radius,
+                             const double length)
+    : KinematicModel(name, 4, 0, 2), radius(radius), length(length) {
+  MORPH_REQUIRE(radius > 0, std::invalid_argument,
+                "Tricycle wheel radius must be positive.");
+  MORPH_REQUIRE(
+      length > 0, std::invalid_argument,
+      "Tricycle distance between the back and front wheels must be positive.");
+}
+
+}  // namespace models
+}  // namespace mechanics
+}  // namespace morphac
+

--- a/src/morphac/mechanics/models/src/tricycle_model.cc
+++ b/src/morphac/mechanics/models/src/tricycle_model.cc
@@ -26,6 +26,44 @@ TricycleModel::TricycleModel(const string name, const double radius,
       "Tricycle distance between the back and front wheels must be positive.");
 }
 
+void TricycleModel::ComputeStateDerivative(const State& state,
+                                           const ControlInput& input,
+                                           State& derivative) const {
+  MORPH_REQUIRE(
+      state.get_size_pose() == 4, std::invalid_argument,
+      "Pose component of the state needs to be of size 3 [x, y, theta]");
+  MORPH_REQUIRE(state.IsVelocityEmpty(), std::invalid_argument,
+                "Velocity component of the state must be empty.");
+  MORPH_REQUIRE(input.get_size() == 2, std::invalid_argument,
+                "Control input must be of size 1.");
+  MORPH_REQUIRE(
+      derivative.get_size_pose() == 4, std::invalid_argument,
+      "Pose component of the derivative needs to be of size 3 [x, y, theta]");
+  MORPH_REQUIRE(derivative.IsVelocityEmpty(), std::invalid_argument,
+                "Velocity component of the derivative must be empty.");
+
+  VectorXd pose_derivative(4);
+  double theta = state.get_pose()(2);
+  double alpha = state.get_pose()(3);
+
+  // Equation of the form xdot = F(x) + G(x)u
+  MatrixXd F = VectorXd::Zero(3);
+  MatrixXd G(4, 2);
+
+  G << radius * cos(alpha) * cos(theta), 0, radius * cos(alpha) * sin(theta), 0,
+      (radius / length) * sin(alpha), 0, 0, 1;
+
+  pose_derivative = F + G * input.get_input_vector();
+  derivative.set_pose_vector(pose_derivative);
+}
+
+State TricycleModel::ComputeStateDerivative(const State& state, const ControlInput& input) const {
+  // Argument checks are performed by the other overloaded function.
+  State derivative = State::CreateLike(state);
+  ComputeStateDerivative(state, input, derivative);
+  return derivative;
+}
+
 }  // namespace models
 }  // namespace mechanics
 }  // namespace morphac

--- a/src/morphac/mechanics/models/test/diffdrive_model_test.cc
+++ b/src/morphac/mechanics/models/test/diffdrive_model_test.cc
@@ -73,23 +73,23 @@ TEST_F(DiffDriveModelTest, DerivativeComputation) {
 
   State derivative = diffdrive_model.ComputeStateDerivative(state1, input1);
   ASSERT_TRUE(derivative.get_pose_vector().isApprox(desired_vector1));
-  ASSERT_TRUE(derivative.is_velocity_empty());
+  ASSERT_TRUE(derivative.IsVelocityEmpty());
 
   diffdrive_model.ComputeStateDerivative(state2, input2, derivative);
   ASSERT_TRUE(derivative.get_pose_vector().isApprox(desired_vector2));
-  ASSERT_TRUE(derivative.is_velocity_empty());
+  ASSERT_TRUE(derivative.IsVelocityEmpty());
 
   diffdrive_model.ComputeStateDerivative(state1, input3, derivative);
   ASSERT_TRUE(derivative.get_pose_vector().isApprox(desired_vector3));
-  ASSERT_TRUE(derivative.is_velocity_empty());
+  ASSERT_TRUE(derivative.IsVelocityEmpty());
 
   diffdrive_model.ComputeStateDerivative(state2, input4, derivative);
   ASSERT_TRUE(derivative.get_pose_vector().isApprox(desired_vector4));
-  ASSERT_TRUE(derivative.is_velocity_empty());
+  ASSERT_TRUE(derivative.IsVelocityEmpty());
 
   diffdrive_model.ComputeStateDerivative(state1, input5, derivative);
   ASSERT_TRUE(derivative.get_pose_vector().isApprox(desired_vector5));
-  ASSERT_TRUE(derivative.is_velocity_empty());
+  ASSERT_TRUE(derivative.IsVelocityEmpty());
 }
 
 TEST_F(DiffDriveModelTest, InvalidDerivativeComputation) {

--- a/src/morphac/mechanics/models/test/diffdrive_model_test.cc
+++ b/src/morphac/mechanics/models/test/diffdrive_model_test.cc
@@ -95,9 +95,12 @@ TEST_F(DiffDriveModelTest, DerivativeComputation) {
 TEST_F(DiffDriveModelTest, InvalidDerivativeComputation) {
   DiffDriveModel diffdrive_model{"diffdrive_model", 1, 1};
   State derivative1{2, 0};
-  State derivative2{3, 3};
+  State derivative2{4, 0};
 
   // Computing the state derivative with incorrect state/input/derivative.
+  ASSERT_THROW(
+      diffdrive_model.ComputeStateDerivative(State{2, 0}, ControlInput{2}),
+      std::invalid_argument);
   ASSERT_THROW(
       diffdrive_model.ComputeStateDerivative(State{4, 0}, ControlInput{2}),
       std::invalid_argument);

--- a/src/morphac/mechanics/models/test/diffdrive_model_test.cc
+++ b/src/morphac/mechanics/models/test/diffdrive_model_test.cc
@@ -1,0 +1,33 @@
+#include "Eigen/Dense"
+#include "gtest/gtest.h"
+
+#include "mechanics/models/include/diffdrive_model.h"
+
+namespace {
+
+using std::string;
+
+using Eigen::MatrixXd;
+using Eigen::VectorXd;
+
+using morphac::constructs::ControlInput;
+using morphac::constructs::State;
+using morphac::mechanics::models::DiffDriveModel;
+
+class DiffDriveModelTest : public ::testing::Test {
+ protected:
+  DiffDriveModelTest() {}
+
+  void SetUp() override {}
+};
+
+TEST_F(DiffDriveModelTest, Sizes) {
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+

--- a/src/morphac/mechanics/models/test/diffdrive_model_test.cc
+++ b/src/morphac/mechanics/models/test/diffdrive_model_test.cc
@@ -21,7 +21,101 @@ class DiffDriveModelTest : public ::testing::Test {
   void SetUp() override {}
 };
 
-TEST_F(DiffDriveModelTest, Sizes) {
+TEST_F(DiffDriveModelTest, Construction) {
+  DiffDriveModel diffdrive_model{"diffdrive_model", 1.5, 2.3};
+
+  ASSERT_EQ(diffdrive_model.name, "diffdrive_model");
+  ASSERT_EQ(diffdrive_model.size_pose, 3);
+  ASSERT_EQ(diffdrive_model.size_velocity, 0);
+  ASSERT_EQ(diffdrive_model.size_input, 2);
+  ASSERT_EQ(diffdrive_model.radius, 1.5);
+  ASSERT_EQ(diffdrive_model.length, 2.3);
+}
+
+TEST_F(DiffDriveModelTest, InvalidConstruction) {
+  ASSERT_THROW(DiffDriveModel("invalid", -1, 1), std::invalid_argument);
+  ASSERT_THROW(DiffDriveModel("invalid", 0, 1), std::invalid_argument);
+  ASSERT_THROW(DiffDriveModel("invalid", 1, -1), std::invalid_argument);
+  ASSERT_THROW(DiffDriveModel("invalid", 1, 0), std::invalid_argument);
+}
+
+TEST_F(DiffDriveModelTest, DerivativeComputation) {
+  DiffDriveModel diffdrive_model{"diffdrive_model", 1.5, 2.5};
+  VectorXd pose_vector1(3), pose_vector2(3);
+  VectorXd input_vector1(2), input_vector2(2), input_vector3(2),
+      input_vector4(2), input_vector5(2);
+  VectorXd desired_vector1(3), desired_vector2(3), desired_vector3(3),
+      desired_vector4(3), desired_vector5(3);
+  pose_vector1 << 3, 4, M_PI / 2;
+  pose_vector2 << -9, 10, 0;
+
+  // Going straight.
+  input_vector1 << 2, 2;
+  // Turning left.
+  input_vector2 << 1, 2;
+  // Turning right.
+  input_vector3 << 2, 1;
+  // Turning in place (to the left).
+  input_vector4 << -2, 2;
+  // Turning in place (to the right).
+  input_vector5 << 2, -2;
+
+  desired_vector1 << 0, 3., 0;
+  desired_vector2 << 2.25, 0, 0.6;
+  desired_vector3 << 0, 2.25, -0.6;
+  desired_vector4 << 0, 0, 2.4;
+  desired_vector5 << 0, 0, -2.4;
+
+  State state1{pose_vector1, VectorXd::Zero(0)};
+  State state2{pose_vector2, VectorXd::Zero(0)};
+  ControlInput input1{input_vector1}, input2{input_vector2},
+      input3{input_vector3}, input4{input_vector4}, input5{input_vector5};
+
+  State derivative = diffdrive_model.ComputeStateDerivative(state1, input1);
+  ASSERT_TRUE(derivative.get_pose_vector().isApprox(desired_vector1));
+  ASSERT_TRUE(derivative.is_velocity_empty());
+
+  diffdrive_model.ComputeStateDerivative(state2, input2, derivative);
+  ASSERT_TRUE(derivative.get_pose_vector().isApprox(desired_vector2));
+  ASSERT_TRUE(derivative.is_velocity_empty());
+
+  diffdrive_model.ComputeStateDerivative(state1, input3, derivative);
+  ASSERT_TRUE(derivative.get_pose_vector().isApprox(desired_vector3));
+  ASSERT_TRUE(derivative.is_velocity_empty());
+
+  diffdrive_model.ComputeStateDerivative(state2, input4, derivative);
+  ASSERT_TRUE(derivative.get_pose_vector().isApprox(desired_vector4));
+  ASSERT_TRUE(derivative.is_velocity_empty());
+
+  diffdrive_model.ComputeStateDerivative(state1, input5, derivative);
+  ASSERT_TRUE(derivative.get_pose_vector().isApprox(desired_vector5));
+  ASSERT_TRUE(derivative.is_velocity_empty());
+}
+
+TEST_F(DiffDriveModelTest, InvalidDerivativeComputation) {
+  DiffDriveModel diffdrive_model{"diffdrive_model", 1, 1};
+  State derivative1{2, 0};
+  State derivative2{3, 3};
+
+  // Computing the state derivative with incorrect state/input/derivative.
+  ASSERT_THROW(
+      diffdrive_model.ComputeStateDerivative(State{4, 0}, ControlInput{2}),
+      std::invalid_argument);
+  ASSERT_THROW(
+      diffdrive_model.ComputeStateDerivative(State{3, 1}, ControlInput{2}),
+      std::invalid_argument);
+  ASSERT_THROW(
+      diffdrive_model.ComputeStateDerivative(State{3, 0}, ControlInput{1}),
+      std::invalid_argument);
+  ASSERT_THROW(
+      diffdrive_model.ComputeStateDerivative(State{3, 0}, ControlInput{3}),
+      std::invalid_argument);
+  ASSERT_THROW(diffdrive_model.ComputeStateDerivative(
+                   State{3, 0}, ControlInput{2}, derivative1),
+               std::invalid_argument);
+  ASSERT_THROW(diffdrive_model.ComputeStateDerivative(
+                   State{3, 0}, ControlInput{2}, derivative2),
+               std::invalid_argument);
 }
 
 }  // namespace

--- a/src/morphac/mechanics/models/test/dubin_model_test.cc
+++ b/src/morphac/mechanics/models/test/dubin_model_test.cc
@@ -9,8 +9,9 @@ using std::string;
 
 using Eigen::VectorXd;
 
-using morphac::mechanics::models::DubinModel;
+using morphac::constructs::ControlInput;
 using morphac::constructs::State;
+using morphac::mechanics::models::DubinModel;
 
 class DubinModelTest : public ::testing::Test {
  protected:
@@ -20,19 +21,59 @@ class DubinModelTest : public ::testing::Test {
 };
 
 TEST_F(DubinModelTest, Sizes) {
-  DubinModel dubin{"dubin_model", 1.5};
+  DubinModel dubin_model{"dubin_model", 1.5};
 
-  ASSERT_EQ(dubin.name, "dubin_model");
-  ASSERT_EQ(dubin.size_pose, 3);
-  ASSERT_EQ(dubin.size_velocity, 0);
-  ASSERT_EQ(dubin.size_input, 1);
-  ASSERT_EQ(dubin.speed, 1.5);
+  ASSERT_EQ(dubin_model.name, "dubin_model");
+  ASSERT_EQ(dubin_model.size_pose, 3);
+  ASSERT_EQ(dubin_model.size_velocity, 0);
+  ASSERT_EQ(dubin_model.size_input, 1);
+  ASSERT_EQ(dubin_model.speed, 1.5);
 }
 
 TEST_F(DubinModelTest, DerivativeComputation) {
-  DubinModel dubin{"dubin_model", 2.5};
+  DubinModel dubin_model{"dubin_model", 2.5};
+  VectorXd pose_vector1(3), pose_vector2(3);
+  VectorXd input_vector1(1), input_vector2(1);
+  VectorXd desired_vector1(3), desired_vector2(3);
+  pose_vector1 << 9, 10, M_PI / 2;
+  pose_vector2 << 1.5, 2.3, 0.;
+  input_vector1 << 5.5;
+  input_vector2 << -1.5;
+  desired_vector1 << 0., 2.5, 5.5;
+  desired_vector2 << 2.5, 0., -1.5;
 
-  //State state1{
+  State state1{pose_vector1, VectorXd::Zero(0)};
+  ControlInput input1{input_vector1};
+  State derivative1{3, 0};
+
+  dubin_model.ComputeStateDerivative(state1, input1, derivative1);
+  ASSERT_TRUE(derivative1.get_pose_vector().isApprox(desired_vector1));
+  ASSERT_TRUE(derivative1.is_velocity_empty());
+
+  State derivative2 = dubin_model.ComputeStateDerivative(
+      State{pose_vector2, VectorXd::Zero(0)}, ControlInput{input_vector2});
+  ASSERT_TRUE(derivative2.get_pose_vector().isApprox(desired_vector2));
+  ASSERT_TRUE(derivative2.is_velocity_empty());
+}
+
+TEST_F(DubinModelTest, InvalidDerivativeComputation) {
+  DubinModel dubin_model{"dubin_model", 1.0};
+  State derivative1{2, 0};
+  State derivative2{3, 1};
+
+  // Computing the state derivative with incorrect state/input/derivative.
+  ASSERT_THROW(dubin_model.ComputeStateDerivative(State{4, 0}, ControlInput{1}),
+               std::invalid_argument);
+  ASSERT_THROW(dubin_model.ComputeStateDerivative(State{3, 1}, ControlInput{1}),
+               std::invalid_argument);
+  ASSERT_THROW(dubin_model.ComputeStateDerivative(State{3, 0}, ControlInput{2}),
+               std::invalid_argument);
+  ASSERT_THROW(dubin_model.ComputeStateDerivative(State{3, 0}, ControlInput{1},
+                                                  derivative1),
+               std::invalid_argument);
+  ASSERT_THROW(dubin_model.ComputeStateDerivative(State{3, 0}, ControlInput{1},
+                                                  derivative2),
+               std::invalid_argument);
 }
 
 }  // namespace

--- a/src/morphac/mechanics/models/test/dubin_model_test.cc
+++ b/src/morphac/mechanics/models/test/dubin_model_test.cc
@@ -17,7 +17,7 @@ class DubinModelTest : public ::testing::Test {
  protected:
   DubinModelTest() {}
 
-  void SetUp() override {}
+  void SetUp() override{};
 };
 
 TEST_F(DubinModelTest, Construction) {
@@ -59,9 +59,11 @@ TEST_F(DubinModelTest, DerivativeComputation) {
 TEST_F(DubinModelTest, InvalidDerivativeComputation) {
   DubinModel dubin_model{"dubin_model", 1.0};
   State derivative1{2, 0};
-  State derivative2{3, 1};
+  State derivative2{4, 0};
 
   // Computing the state derivative with incorrect state/input/derivative.
+  ASSERT_THROW(dubin_model.ComputeStateDerivative(State{2, 0}, ControlInput{1}),
+               std::invalid_argument);
   ASSERT_THROW(dubin_model.ComputeStateDerivative(State{4, 0}, ControlInput{1}),
                std::invalid_argument);
   ASSERT_THROW(dubin_model.ComputeStateDerivative(State{3, 1}, ControlInput{1}),

--- a/src/morphac/mechanics/models/test/dubin_model_test.cc
+++ b/src/morphac/mechanics/models/test/dubin_model_test.cc
@@ -1,0 +1,26 @@
+#include "Eigen/Dense"
+#include "gtest/gtest.h"
+
+#include "mechanics/models/include/dubin_model.h"
+
+namespace {
+
+using std::string;
+
+using Eigen::VectorXd;
+
+using morphac::mechanics::models::DubinModel;
+
+class DubinModelTest : public ::testing::Test {
+ protected:
+  DubinModelTest() {}
+
+  void SetUp() override {}
+};
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/morphac/mechanics/models/test/dubin_model_test.cc
+++ b/src/morphac/mechanics/models/test/dubin_model_test.cc
@@ -48,12 +48,12 @@ TEST_F(DubinModelTest, DerivativeComputation) {
 
   dubin_model.ComputeStateDerivative(state1, input1, derivative1);
   ASSERT_TRUE(derivative1.get_pose_vector().isApprox(desired_vector1));
-  ASSERT_TRUE(derivative1.is_velocity_empty());
+  ASSERT_TRUE(derivative1.IsVelocityEmpty());
 
   State derivative2 = dubin_model.ComputeStateDerivative(
       State{pose_vector2, VectorXd::Zero(0)}, ControlInput{input_vector2});
   ASSERT_TRUE(derivative2.get_pose_vector().isApprox(desired_vector2));
-  ASSERT_TRUE(derivative2.is_velocity_empty());
+  ASSERT_TRUE(derivative2.IsVelocityEmpty());
 }
 
 TEST_F(DubinModelTest, InvalidDerivativeComputation) {

--- a/src/morphac/mechanics/models/test/dubin_model_test.cc
+++ b/src/morphac/mechanics/models/test/dubin_model_test.cc
@@ -10,6 +10,7 @@ using std::string;
 using Eigen::VectorXd;
 
 using morphac::mechanics::models::DubinModel;
+using morphac::constructs::State;
 
 class DubinModelTest : public ::testing::Test {
  protected:
@@ -17,6 +18,22 @@ class DubinModelTest : public ::testing::Test {
 
   void SetUp() override {}
 };
+
+TEST_F(DubinModelTest, Sizes) {
+  DubinModel dubin{"dubin_model", 1.5};
+
+  ASSERT_EQ(dubin.name, "dubin_model");
+  ASSERT_EQ(dubin.size_pose, 3);
+  ASSERT_EQ(dubin.size_velocity, 0);
+  ASSERT_EQ(dubin.size_input, 1);
+  ASSERT_EQ(dubin.speed, 1.5);
+}
+
+TEST_F(DubinModelTest, DerivativeComputation) {
+  DubinModel dubin{"dubin_model", 2.5};
+
+  //State state1{
+}
 
 }  // namespace
 

--- a/src/morphac/mechanics/models/test/dubin_model_test.cc
+++ b/src/morphac/mechanics/models/test/dubin_model_test.cc
@@ -20,7 +20,7 @@ class DubinModelTest : public ::testing::Test {
   void SetUp() override {}
 };
 
-TEST_F(DubinModelTest, Sizes) {
+TEST_F(DubinModelTest, Construction) {
   DubinModel dubin_model{"dubin_model", 1.5};
 
   ASSERT_EQ(dubin_model.name, "dubin_model");
@@ -65,6 +65,8 @@ TEST_F(DubinModelTest, InvalidDerivativeComputation) {
   ASSERT_THROW(dubin_model.ComputeStateDerivative(State{4, 0}, ControlInput{1}),
                std::invalid_argument);
   ASSERT_THROW(dubin_model.ComputeStateDerivative(State{3, 1}, ControlInput{1}),
+               std::invalid_argument);
+  ASSERT_THROW(dubin_model.ComputeStateDerivative(State{3, 0}, ControlInput{0}),
                std::invalid_argument);
   ASSERT_THROW(dubin_model.ComputeStateDerivative(State{3, 0}, ControlInput{2}),
                std::invalid_argument);

--- a/src/morphac/mechanics/models/test/kinematic_model_test.cc
+++ b/src/morphac/mechanics/models/test/kinematic_model_test.cc
@@ -1,14 +1,13 @@
 #include "Eigen/Dense"
 #include "gtest/gtest.h"
 
-#include "mechanics/include/kinematic_model.h"
+#include "mechanics/models/include/kinematic_model.h"
 
 namespace {
 
 using std::make_shared;
 using std::shared_ptr;
 using std::string;
-using std::unordered_map;
 
 using Eigen::VectorXd;
 

--- a/src/morphac/mechanics/models/test/kinematic_model_test.cc
+++ b/src/morphac/mechanics/models/test/kinematic_model_test.cc
@@ -13,7 +13,7 @@ using Eigen::VectorXd;
 
 using morphac::constructs::ControlInput;
 using morphac::constructs::State;
-using morphac::mechanics::KinematicModel;
+using morphac::mechanics::models::KinematicModel;
 
 class SomeKinematicModel : public KinematicModel {
  public:

--- a/src/morphac/mechanics/models/test/kinematic_model_test.cc
+++ b/src/morphac/mechanics/models/test/kinematic_model_test.cc
@@ -77,8 +77,8 @@ TEST_F(KinematicModelTest, Subclass) {
       expected_velocity_derivative.isApprox(derivative1.get_velocity_vector()));
 
   // Changing the values of the state
-  state.set_pose_at(2, 3);
-  state.set_velocity_at(1, 7);
+  state.get_pose()(2) = 3;
+  state.get_velocity()(1) = 7;
 
   // Now we use the other overload to compute the derivative.
   State derivative2 = model.ComputeStateDerivative(state, input);

--- a/src/morphac/mechanics/models/test/kinematic_model_test.cc
+++ b/src/morphac/mechanics/models/test/kinematic_model_test.cc
@@ -5,8 +5,6 @@
 
 namespace {
 
-using std::make_shared;
-using std::shared_ptr;
 using std::string;
 
 using Eigen::VectorXd;

--- a/src/morphac/mechanics/models/test/tricycle_model_test.cc
+++ b/src/morphac/mechanics/models/test/tricycle_model_test.cc
@@ -96,6 +96,35 @@ TEST_F(TricycleModelTest, DerivativeComputation) {
   ASSERT_TRUE(derivative.IsVelocityEmpty());
 }
 
+TEST_F(TricycleModelTest, InvalidDerivativeComputation) {
+  TricycleModel tricycle_model{"tricycle_model", 1, 1};
+  State derivative1{3, 0};
+  State derivative2{5, 0};
+
+  // Computing the state derivative with incorrect state/input/derivative.
+  ASSERT_THROW(
+      tricycle_model.ComputeStateDerivative(State{3, 0}, ControlInput{2}),
+      std::invalid_argument);
+  ASSERT_THROW(
+      tricycle_model.ComputeStateDerivative(State{5, 0}, ControlInput{2}),
+      std::invalid_argument);
+  ASSERT_THROW(
+      tricycle_model.ComputeStateDerivative(State{3, 1}, ControlInput{2}),
+      std::invalid_argument);
+  ASSERT_THROW(
+      tricycle_model.ComputeStateDerivative(State{3, 0}, ControlInput{1}),
+      std::invalid_argument);
+  ASSERT_THROW(
+      tricycle_model.ComputeStateDerivative(State{3, 0}, ControlInput{3}),
+      std::invalid_argument);
+  ASSERT_THROW(tricycle_model.ComputeStateDerivative(
+                   State{3, 0}, ControlInput{2}, derivative1),
+               std::invalid_argument);
+  ASSERT_THROW(tricycle_model.ComputeStateDerivative(
+                   State{3, 0}, ControlInput{2}, derivative2),
+               std::invalid_argument);
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {

--- a/src/morphac/mechanics/models/test/tricycle_model_test.cc
+++ b/src/morphac/mechanics/models/test/tricycle_model_test.cc
@@ -1,0 +1,30 @@
+#include "Eigen/Dense"
+#include "gtest/gtest.h"
+
+#include "mechanics/models/include/tricycle_model.h"
+
+namespace {
+
+using std::string;
+
+using Eigen::VectorXd;
+
+using morphac::constructs::ControlInput;
+using morphac::constructs::State;
+using morphac::mechanics::models::TricycleModel;
+
+class TricycleModelTest : public ::testing::Test {
+ protected:
+  TricycleModelTest() {}
+
+  void SetUp() override {}
+};
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+
+

--- a/src/morphac/mechanics/models/test/tricycle_model_test.cc
+++ b/src/morphac/mechanics/models/test/tricycle_model_test.cc
@@ -38,6 +38,64 @@ TEST_F(TricycleModelTest, InvalidConstruction) {
   ASSERT_THROW(TricycleModel("invalid", 1, -1), std::invalid_argument);
 }
 
+TEST_F(TricycleModelTest, DerivativeComputation) {
+  TricycleModel tricycle_model{"tricycle_model", 1.5, 2.5};
+  VectorXd pose_vector1(4), pose_vector2(4), pose_vector3(4), pose_vector4(4);
+  VectorXd input_vector1(2), input_vector2(2), input_vector3(2),
+      input_vector4(2), input_vector5(2);
+  VectorXd desired_vector1(4), desired_vector2(4), desired_vector3(4),
+      desired_vector4(4), desired_vector5(4);
+
+  pose_vector1 << 3, 4, M_PI / 2, M_PI / 2;
+  pose_vector2 << -9, 10, 0, 0;
+  pose_vector3 << 5, -13, M_PI / 2, 0;
+  pose_vector4 << -2, -7, 0, M_PI / 2;
+
+  // Forward velocity is zero.
+  input_vector1 << 0, 1.;
+  // Turning left.
+  input_vector2 << 2, 2;
+  // Not turning.
+  input_vector3 << 2, 0;
+  // Turning right.
+  input_vector4 << 2, -2;
+  input_vector5 << 10, 5;
+
+  State state1{pose_vector1, VectorXd::Zero(0)};
+  State state2{pose_vector2, VectorXd::Zero(0)};
+  State state3{pose_vector3, VectorXd::Zero(0)};
+  State state4{pose_vector4, VectorXd::Zero(0)};
+  ControlInput input1{input_vector1}, input2{input_vector2},
+      input3{input_vector3}, input4{input_vector4}, input5{input_vector5};
+
+  // Zero forward velocity does not make the robot move in x, y, or theta.
+  desired_vector1 << 0, 0, 0, 1.;
+  desired_vector2 << 0, 0, 1.2, 2;
+  desired_vector3 << 3, 0, 0, 0;
+  desired_vector4 << 0, 3, 0, -2;
+  desired_vector5 << 0, 0, 6, 5;
+
+  State derivative = tricycle_model.ComputeStateDerivative(state1, input1);
+  ASSERT_TRUE(derivative.get_pose_vector().isApprox(desired_vector1));
+  ASSERT_TRUE(derivative.IsVelocityEmpty());
+
+  tricycle_model.ComputeStateDerivative(state1, input2, derivative);
+  ASSERT_TRUE(derivative.get_pose_vector().isApprox(desired_vector2));
+  ASSERT_TRUE(derivative.IsVelocityEmpty());
+
+  tricycle_model.ComputeStateDerivative(state2, input3, derivative);
+  ASSERT_TRUE(derivative.get_pose_vector().isApprox(desired_vector3));
+  ASSERT_TRUE(derivative.IsVelocityEmpty());
+
+  tricycle_model.ComputeStateDerivative(state3, input4, derivative);
+  ASSERT_TRUE(derivative.get_pose_vector().isApprox(desired_vector4));
+  ASSERT_TRUE(derivative.IsVelocityEmpty());
+
+  tricycle_model.ComputeStateDerivative(state4, input5, derivative);
+  ASSERT_TRUE(derivative.get_pose_vector().isApprox(desired_vector5));
+  ASSERT_TRUE(derivative.IsVelocityEmpty());
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {

--- a/src/morphac/mechanics/models/test/tricycle_model_test.cc
+++ b/src/morphac/mechanics/models/test/tricycle_model_test.cc
@@ -20,11 +20,28 @@ class TricycleModelTest : public ::testing::Test {
   void SetUp() override {}
 };
 
+TEST_F(TricycleModelTest, Construction) {
+  TricycleModel tricycle_model{"tricycle_model", 1.5, 2.3};
+
+  ASSERT_EQ(tricycle_model.name, "tricycle_model");
+  ASSERT_EQ(tricycle_model.size_pose, 4);
+  ASSERT_EQ(tricycle_model.size_velocity, 0);
+  ASSERT_EQ(tricycle_model.size_input, 2);
+  ASSERT_EQ(tricycle_model.radius, 1.5);
+  ASSERT_EQ(tricycle_model.length, 2.3);
+}
+
+TEST_F(TricycleModelTest, InvalidConstruction) {
+  ASSERT_THROW(TricycleModel("invalid", -1, 1), std::invalid_argument);
+  ASSERT_THROW(TricycleModel("invalid", 0, 1), std::invalid_argument);
+  ASSERT_THROW(TricycleModel("invalid", 1, -1), std::invalid_argument);
+  ASSERT_THROW(TricycleModel("invalid", 1, -1), std::invalid_argument);
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-
 

--- a/src/morphac/robot/blueprint/include/footprint2D.h
+++ b/src/morphac/robot/blueprint/include/footprint2D.h
@@ -21,7 +21,7 @@ class Footprint2D {
 };
 
 
-} // namespace models
+} // namespace blueprint
 } // namespace robot
 } // namespace morphac
 

--- a/src/morphac/robot/blueprint/include/robot2D.h
+++ b/src/morphac/robot/blueprint/include/robot2D.h
@@ -44,7 +44,7 @@ class Robot2D {
   const std::unique_ptr<morphac::constructs::State> state_;
 };
 
-}  // namespace models
+}  // namespace blueprint
 }  // namespace robot
 }  // namespace morphac
 

--- a/src/morphac/robot/blueprint/include/robot2D.h
+++ b/src/morphac/robot/blueprint/include/robot2D.h
@@ -18,10 +18,10 @@ namespace blueprint {
 class Robot2D {
  public:
   Robot2D(const std::string name,
-          const morphac::mechanics::KinematicModel& kinematic_model,
+          const morphac::mechanics::models::KinematicModel& kinematic_model,
           const morphac::robot::blueprint::Footprint2D& footprint);
   Robot2D(const std::string name,
-          const morphac::mechanics::KinematicModel& kinematic_model,
+          const morphac::mechanics::models::KinematicModel& kinematic_model,
           const morphac::robot::blueprint::Footprint2D& footprint,
           const morphac::constructs::State& initial_state);
 
@@ -31,7 +31,7 @@ class Robot2D {
       const morphac::constructs::ControlInput& input) const;
 
   const std::string get_name() const;
-  const morphac::mechanics::KinematicModel& get_kinematic_model() const;
+  const morphac::mechanics::models::KinematicModel& get_kinematic_model() const;
   const morphac::robot::blueprint::Footprint2D get_footprint() const;
   const morphac::constructs::State& get_state() const;
   const morphac::constructs::Pose& get_pose() const;
@@ -39,7 +39,7 @@ class Robot2D {
 
  private:
   const std::string name_;
-  const morphac::mechanics::KinematicModel& kinematic_model_;
+  const morphac::mechanics::models::KinematicModel& kinematic_model_;
   const morphac::robot::blueprint::Footprint2D footprint_;
   const std::unique_ptr<morphac::constructs::State> state_;
 };

--- a/src/morphac/robot/blueprint/include/robot2D.h
+++ b/src/morphac/robot/blueprint/include/robot2D.h
@@ -8,7 +8,7 @@
 #include "constructs/include/pose.h"
 #include "constructs/include/state.h"
 #include "constructs/include/velocity.h"
-#include "mechanics/include/kinematic_model.h"
+#include "mechanics/models/include/kinematic_model.h"
 #include "robot/blueprint/include/footprint2D.h"
 
 namespace morphac {

--- a/src/morphac/robot/blueprint/src/robot2D.cc
+++ b/src/morphac/robot/blueprint/src/robot2D.cc
@@ -62,6 +62,6 @@ const Pose& Robot2D::get_pose() const { return state_->get_pose(); }
 
 const Velocity& Robot2D::get_velocity() const { return state_->get_velocity(); }
 
-}  // namespace models
+}  // namespace blueprint
 }  // namespace robot
 }  // namespace morphac

--- a/src/morphac/robot/blueprint/src/robot2D.cc
+++ b/src/morphac/robot/blueprint/src/robot2D.cc
@@ -13,7 +13,7 @@ using Eigen::MatrixXd;
 using morphac::constructs::Pose;
 using morphac::constructs::State;
 using morphac::constructs::Velocity;
-using morphac::mechanics::KinematicModel;
+using morphac::mechanics::models::KinematicModel;
 using morphac::robot::blueprint::Footprint2D;
 
 Robot2D::Robot2D(const string name, const KinematicModel& kinematic_model,

--- a/src/morphac/robot/blueprint/test/robot2D_test.cc
+++ b/src/morphac/robot/blueprint/test/robot2D_test.cc
@@ -16,7 +16,7 @@ using morphac::constructs::ControlInput;
 using morphac::constructs::Pose;
 using morphac::constructs::State;
 using morphac::constructs::Velocity;
-using morphac::mechanics::KinematicModel;
+using morphac::mechanics::models::KinematicModel;
 using morphac::robot::blueprint::Footprint2D;
 using morphac::robot::blueprint::Robot2D;
 


### PR DESCRIPTION
## Specifc kinematic models and some refactoring

* Dubin, diffdrive and tricycle model with tests.
* Bug fixes and refactors in `Pose`, `Velocity`, `ControlInput` and `State`. Most importantly, the `get_at` accessors have been replaced with the `operator()` overload. Also expanded tests to include this and other bug fixes.